### PR TITLE
outcomes = TRUE feature for predict.workflow()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,4 +36,4 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/R/predict.R
+++ b/R/predict.R
@@ -19,6 +19,8 @@
 #' @param new_data A data frame containing the new predictors to preprocess
 #'   and predict on
 #'
+#' @param outcomes A logical. Should the outcomes be processed and returned as well?
+#'
 #' @return
 #' A data frame of model predictions, with as many rows as `new_data` has.
 #'
@@ -47,7 +49,7 @@
 #' # This will automatically `bake()` the recipe on `testing`,
 #' # applying the log step to `disp`, and then fit the regression.
 #' predict(fit_workflow, testing)
-predict.workflow <- function(object, new_data, type = NULL, opts = list(), ...) {
+predict.workflow <- function(object, new_data, type = NULL, opts = list(), outcomes = FALSE, ...) {
   workflow <- object
 
   if (!workflow$trained) {
@@ -55,10 +57,16 @@ predict.workflow <- function(object, new_data, type = NULL, opts = list(), ...) 
   }
 
   blueprint <- workflow$pre$mold$blueprint
-  forged <- hardhat::forge(new_data, blueprint)
+  forged <- hardhat::forge(new_data, blueprint, outcomes = outcomes)
   new_data <- forged$predictors
 
   fit <- workflow$fit$fit
 
-  predict(fit, new_data, type = type, opts = opts, ...)
+  predict_df <- predict(fit, new_data, type = type, opts = opts, ...)
+
+  if(outcomes) {
+    predict_df <- cbind(predict_df, forged$outcomes)
+  }
+
+  predict_df
 }

--- a/man/predict-workflow.Rd
+++ b/man/predict-workflow.Rd
@@ -5,7 +5,7 @@
 \alias{predict.workflow}
 \title{Predict from a workflow}
 \usage{
-\method{predict}{workflow}(object, new_data, type = NULL, opts = list(), ...)
+\method{predict}{workflow}(object, new_data, type = NULL, opts = list(), outcomes = FALSE, ...)
 }
 \arguments{
 \item{object}{A workflow that has been fit by \code{\link[=fit.workflow]{fit.workflow()}}}
@@ -22,6 +22,8 @@ based on the model's mode.}
 predict function that will be used when \code{type = "raw"}. The
 list should not include options for the model object or the
 new data being predicted.}
+
+\item{outcomes}{A logical. Should the outcomes be processed and returned as well?}
 
 \item{...}{Arguments to the underlying model's prediction
 function cannot be passed here (see \code{opts}). There are some

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -121,15 +121,15 @@ test_that("blueprint will get passed on to hardhat::forge()", {
 test_that("outcomes = TRUE works.", {
   # outcome with transformation from formula
   mod <- parsnip::linear_reg()
+  mod <- parsnip::set_engine(mod, "lm")
   wf <- add_formula(add_model(workflow(), mod), formula = log(mpg) ~ .)
   fit <- fit(wf, mtcars)
   prediction_with_outcome <- predict(fit, mtcars, outcomes = TRUE)
   expect_equal(log(mtcars$mpg), prediction_with_outcome$`log(mpg)`)
 
   # outcome with transformetion from recipe
-  mod <- parsnip::linear_reg()
-  rec <- recipe(mpg ~ ., mtcars)
-  rec <- step_log(rec, all_outcomes())
+  rec <- recipes::recipe(mpg ~ ., mtcars)
+  rec <- recipes::step_log(rec, recipes::all_outcomes())
   wf <- add_model(workflow(), mod)
   wf <- add_recipe(wf, rec)
   fit <- fit(wf, mtcars)

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -117,3 +117,28 @@ test_that("blueprint will get passed on to hardhat::forge()", {
 
   expect_false(identical(prediction_with_intercept, prediction_no_intercept))
 })
+
+test_that("outcomes = TRUE works.", {
+  # outcome with transformation from formula
+  mod <- parsnip::linear_reg()
+  wf <- add_formula(add_model(workflow(), mod), formula = log(mpg) ~ .)
+  fit <- fit(wf, mtcars)
+  prediction_with_outcome <- predict(fit, mtcars, outcomes = TRUE)
+  expect_equal(log(mtcars$mpg), prediction_with_outcome$`log(mpg)`)
+
+  # outcome with transformetion from recipe
+  mod <- parsnip::linear_reg()
+  rec <- recipe(mpg ~ ., mtcars)
+  rec <- step_log(rec, all_outcomes())
+  wf <- add_model(workflow(), mod)
+  wf <- add_recipe(wf, rec)
+  fit <- fit(wf, mtcars)
+  prediction_with_outcome <- predict(fit, mtcars, outcomes = TRUE)
+  expect_equal(log(mtcars$mpg), prediction_with_outcome$mpg)
+
+  # gives error when the new_data do not contain the outcome(s) column(s)
+  mtcars_without_outcome_column <- mtcars
+  mtcars_without_outcome_column$mpg <- NULL
+  expect_error(predict(fit, mtcars_without_outcome_column, outcomes = TRUE))
+})
+


### PR DESCRIPTION
Implements outcomes = TRUE for predict.workflow() as suggested at #35 