### PR TITLE
Add `required_pkgs.workflow()` method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Depends:
 Imports: 
     cli (>= 2.0.0),
     ellipsis (>= 0.2.0),
-    generics,
+    generics (>= 0.1.0),
     glue,
     hardhat (>= 0.1.4),
     parsnip (>= 0.1.5),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workflows
 Title: Modeling Workflows
-Version: 0.2.1.9000
+Version: 0.2.1.9001
 Authors@R: 
     c(person(given = "Davis",
              family = "Vaughan",

--- a/R/tune.R
+++ b/R/tune.R
@@ -1,0 +1,29 @@
+# @export - lazily and conditionally registered in .onLoad()
+required_pkgs_workflow <- function(x, infra = TRUE, ...) {
+  out <- character()
+
+  if (has_spec(x)) {
+    model <- pull_workflow_spec(x)
+    pkgs <- generics::required_pkgs(model, infra = infra)
+    out <- c(pkgs, out)
+  }
+
+  if (has_preprocessor_recipe(x)) {
+    preprocessor <- pull_workflow_preprocessor(x)
+
+    # This also has the side effect of loading recipes, ensuring that its
+    # S3 methods for `required_pkgs()` are registered
+    if (!is_installed("recipes")) {
+      glubort(
+        "The recipes package must be installed to compute the ",
+        "`required_pkgs()` of a workflow with a recipe preprocessor."
+      )
+    }
+
+    pkgs <- generics::required_pkgs(preprocessor, infra = infra)
+    out <- c(pkgs, out)
+  }
+
+  out <- unique(out)
+  out
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -6,6 +6,11 @@
   vctrs::s3_register("butcher::axe_data", "workflow")
   vctrs::s3_register("butcher::axe_env", "workflow")
   vctrs::s3_register("butcher::axe_fitted", "workflow")
+
+  if (rlang::is_installed("tune") && utils::packageVersion("tune") >= "0.1.3.9001") {
+    # `required_pkgs.workflow()` moved from tune to workflows
+    vctrs::s3_register("generics::required_pkgs", "workflow", required_pkgs_workflow)
+  }
 }
 
 # nocov end

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,70 +1,11 @@
 # nocov start
 
 .onLoad <- function(libname, pkgname) {
-  s3_register("butcher::axe_call", "workflow")
-  s3_register("butcher::axe_ctrl", "workflow")
-  s3_register("butcher::axe_data", "workflow")
-  s3_register("butcher::axe_env", "workflow")
-  s3_register("butcher::axe_fitted", "workflow")
+  vctrs::s3_register("butcher::axe_call", "workflow")
+  vctrs::s3_register("butcher::axe_ctrl", "workflow")
+  vctrs::s3_register("butcher::axe_data", "workflow")
+  vctrs::s3_register("butcher::axe_env", "workflow")
+  vctrs::s3_register("butcher::axe_fitted", "workflow")
 }
-
-s3_register <- function(generic, class, method = NULL) {
-  stopifnot(is.character(generic), length(generic) == 1)
-  stopifnot(is.character(class), length(class) == 1)
-
-  pieces <- strsplit(generic, "::")[[1]]
-  stopifnot(length(pieces) == 2)
-  package <- pieces[[1]]
-  generic <- pieces[[2]]
-
-  caller <- parent.frame()
-
-  get_method_env <- function() {
-    top <- topenv(caller)
-    if (isNamespace(top)) {
-      asNamespace(environmentName(top))
-    } else {
-      caller
-    }
-  }
-  get_method <- function(method, env) {
-    if (is.null(method)) {
-      get(paste0(generic, ".", class), envir = get_method_env())
-    } else {
-      method
-    }
-  }
-
-  method_fn <- get_method(method)
-  stopifnot(is.function(method_fn))
-
-  # Always register hook in case package is later unloaded & reloaded
-  setHook(
-    packageEvent(package, "onLoad"),
-    function(...) {
-      ns <- asNamespace(package)
-
-      # Refresh the method, it might have been updated by `devtools::load_all()`
-      method_fn <- get_method(method)
-
-      registerS3method(generic, class, method_fn, envir = ns)
-    }
-  )
-
-  # Avoid registration failures during loading (pkgload or regular)
-  if (!isNamespaceLoaded(package)) {
-    return(invisible())
-  }
-
-  envir <- asNamespace(package)
-
-  # Only register if generic can be accessed
-  if (exists(generic, envir)) {
-    registerS3method(generic, class, method_fn, envir = envir)
-  }
-
-  invisible()
-}
-
 
 # nocov end

--- a/tests/testthat/test-tune.R
+++ b/tests/testthat/test-tune.R
@@ -1,0 +1,29 @@
+test_that("can compute required packages of a workflow - formula", {
+  skip_if_not_installed("tune")
+
+  mod <- parsnip::linear_reg()
+  mod <- parsnip::set_engine(mod, "lm")
+
+  workflow <- workflow()
+  workflow <- add_formula(workflow, mpg ~ cyl)
+  workflow <- add_model(workflow, mod)
+
+  expect_true("stats" %in% generics::required_pkgs(workflow))
+})
+
+test_that("can compute required packages of a workflow - recipes", {
+  skip_if_not_installed("tune")
+  skip_if_not_installed("recipes")
+
+  mod <- parsnip::linear_reg()
+  mod <- parsnip::set_engine(mod, "lm")
+
+  rec <- recipes::recipe(mpg ~ cyl, mtcars)
+  rec <- recipes::step_ica(rec, cyl)
+
+  workflow <- workflow()
+  workflow <- add_recipe(workflow, rec)
+  workflow <- add_model(workflow, mod)
+
+  expect_true("dimRed" %in% generics::required_pkgs(workflow))
+})


### PR DESCRIPTION
This has been moved to workflows from tune. This is a joint PR with https://github.com/tidymodels/tune/pull/360

On the workflows end, we:

- bump the version to 0.2.1.9001 for tune to check against
- only register the `required_pkgs.workflow()` method if tune is installed and its version is above or equal to 0.1.3.9001, which was done in https://github.com/tidymodels/tune/pull/360 where we removed the method from tune

On the tune end, we:

- bump the version to 0.1.3.9001 for workflows to check against
- require at least workflows 0.2.1.9001, which is guaranteed to have the `required_pkgs.workflow()` method
- remove the `required_pkgs.workflow()` method from tune

This should allow us to send workflows to CRAN without any reliance on tune 