### PR TITLE
Options to pass recipe and model to workflow constructor

### DIFF
--- a/R/workflow.R
+++ b/R/workflow.R
@@ -3,13 +3,13 @@
 #' A `workflow` is a container object that aggregates information required to
 #' fit and predict from a model. This information might be a recipe used in
 #' preprocessing or the model specification. The recipe can be specified either
-#' as an argument or through [add_recipe()]. The model specification can be 
+#' as an argument or through [add_recipe()]. The model specification can be
 #' specified as either an argument or through [add_model()].
 #'
 #' @param rec Optionally, a recipe created using [recipes::recipe()].
-#' 
+#'
 #' @param mod Optionally, a parsnip model specification.
-#' 
+#'
 #' @return
 #' A new `workflow` object.
 #'
@@ -50,18 +50,18 @@
 #'   )
 #'
 #' fit(variable_wf, attrition)
-#' 
+#'
 #' # Alternatively, the recipe and model can be specifed on construction
 #' model_wf <- workflow(recipe, model)
-#' 
+#'
 #' @export
 workflow <- function(rec = NULL, mod = NULL) {
   wf <- new_workflow()
 
   if (!is.null(rec))
-    wf %>% add_recipe(rec)
+    wf <- add_recipe(wf, rec)
   if (!is.null(mod))
-    wf %>% add_model(mod)
+    wf <- add_model(wf, mod)
 
   wf
 }

--- a/R/workflow.R
+++ b/R/workflow.R
@@ -46,8 +46,15 @@
 #'
 #' fit(variable_wf, attrition)
 #' @export
-workflow <- function() {
-  new_workflow()
+workflow <- function(rec = NULL, mod = NULL) {
+  wf <- new_workflow()
+
+  if (!is.null(rec))
+    wf %>% add_recipe(rec)
+  if (!is.null(mod))
+    wf %>% add_model(mod)
+
+  wf
 }
 
 # ------------------------------------------------------------------------------

--- a/R/workflow.R
+++ b/R/workflow.R
@@ -2,9 +2,14 @@
 #'
 #' A `workflow` is a container object that aggregates information required to
 #' fit and predict from a model. This information might be a recipe used in
-#' preprocessing, specified through [add_recipe()], or the model specification
-#' to fit, specified through [add_model()].
+#' preprocessing or the model specification. The recipe can be specified either
+#' as an argument or through [add_recipe()]. The model specification can be 
+#' specified as either an argument or through [add_model()].
 #'
+#' @param rec Optionally, a recipe created using [recipes::recipe()].
+#' 
+#' @param mod Optionally, a parsnip model specification.
+#' 
 #' @return
 #' A new `workflow` object.
 #'
@@ -45,6 +50,10 @@
 #'   )
 #'
 #' fit(variable_wf, attrition)
+#' 
+#' # Alternatively, the recipe and model can be specifed on construction
+#' model_wf <- workflow(recipe, model)
+#' 
 #' @export
 workflow <- function(rec = NULL, mod = NULL) {
   wf <- new_workflow()

--- a/tests/testthat/test-workflow.R
+++ b/tests/testthat/test-workflow.R
@@ -28,6 +28,17 @@ test_that("workflow must be the first argument when adding actions", {
   expect_error(add_model(1, mod), "must be a workflow")
 })
 
+test_that("can create workflow with recipe and model", {
+  rec <- recipes::recipe(mpg ~ cyl, mtcars)
+  mod <- parsnip::linear_reg()
+
+  workflow <- workflow(rec, mod)
+
+  expect_s3_class(workflow, "workflow")
+  expect_s3_class(workflow$pre$actions$recipe, "action_recipe")
+  expect_s3_class(workflow$fit$actions$model, "action_model")
+})
+
 # ------------------------------------------------------------------------------
 # new_workflow()
 


### PR DESCRIPTION
Closes #108 by adding optional arguments to `workflow` constructor.