### PR TITLE
Add `preprocessor` and `spec` arguments to `workflow()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # workflows (development version)
 
+* `workflow()` has gained new `preprocessor` and `spec` arguments for adding
+  a preprocessor (such as a recipe or formula) and a parsnip model specification
+  directly to a workflow upon creation. In many cases, this can reduce the
+  lines of code required to construct a complete workflow (#108).
+  
 * New `extract_*()` functions have been added that supersede the existing
   `pull_*()` functions. This is part of a larger move across the tidymodels
   packages towards a family of generic `extract_*()` functions. The `pull_*()`

--- a/R/workflow.R
+++ b/R/workflow.R
@@ -1,9 +1,25 @@
 #' Create a workflow
 #'
+#' @description
 #' A `workflow` is a container object that aggregates information required to
 #' fit and predict from a model. This information might be a recipe used in
 #' preprocessing, specified through [add_recipe()], or the model specification
 #' to fit, specified through [add_model()].
+#'
+#' The `preprocessor` and `spec` arguments allow you add components to a
+#' workflow quickly, without having to go through the `add_*()` functions, such
+#' as [add_recipe()] or [add_model()]. However, if you need to control any of
+#' the optional arguments to those functions, such as the `blueprint` or the
+#' model `formula`, then you should use the `add_*()` functions directly
+#' instead.
+#'
+#' @param preprocessor An optional preprocessor to add to the workflow. One of:
+#'   - A formula, passed on to [add_formula()].
+#'   - A recipe, passed on to [add_recipe()].
+#'   - A [workflow_variables()] object, passed on to [add_variables()].
+#'
+#' @param spec An optional parsnip model specification to add to the workflow.
+#'   Passed on to [add_model()].
 #'
 #' @return
 #' A new `workflow` object.
@@ -21,33 +37,57 @@
 #' model <- logistic_reg() %>%
 #'   set_engine("glm")
 #'
-#' base_wf <- workflow() %>%
-#'   add_model(model)
+#' formula <- Attrition ~ BusinessTravel + YearsSinceLastPromotion + OverTime
 #'
-#' formula_wf <- base_wf %>%
-#'   add_formula(Attrition ~ BusinessTravel + YearsSinceLastPromotion + OverTime)
+#' wf_formula <- workflow(formula, model)
 #'
-#' fit(formula_wf, attrition)
+#' fit(wf_formula, attrition)
 #'
 #' recipe <- recipe(Attrition ~ ., attrition) %>%
 #'   step_dummy(all_nominal(), -Attrition) %>%
 #'   step_corr(all_predictors(), threshold = 0.8)
 #'
-#' recipe_wf <- base_wf %>%
-#'   add_recipe(recipe)
+#' wf_recipe <- workflow(recipe, model)
 #'
-#' fit(recipe_wf, attrition)
+#' fit(wf_recipe, attrition)
 #'
-#' variable_wf <- base_wf %>%
-#'   add_variables(
-#'     Attrition,
-#'     c(BusinessTravel, YearsSinceLastPromotion, OverTime)
-#'   )
+#' variables <- workflow_variables(
+#'   Attrition,
+#'   c(BusinessTravel, YearsSinceLastPromotion, OverTime)
+#' )
 #'
-#' fit(variable_wf, attrition)
+#' wf_variables <- workflow(variables, model)
+#'
+#' fit(wf_variables, attrition)
 #' @export
-workflow <- function() {
-  new_workflow()
+workflow <- function(preprocessor = NULL, spec = NULL) {
+  out <- new_workflow()
+
+  if (!is_null(preprocessor)) {
+    out <- add_preprocessor(out, preprocessor)
+  }
+
+  if (!is_null(spec)) {
+    out <- add_model(out, spec)
+  }
+
+  out
+}
+
+add_preprocessor <- function(x, preprocessor) {
+  if (is_formula(preprocessor)) {
+    return(add_formula(x, preprocessor))
+  }
+
+  if (is_recipe(preprocessor)) {
+    return(add_recipe(x, preprocessor))
+  }
+
+  if (is_workflow_variables(preprocessor)) {
+    return(add_variables(x, variables = preprocessor))
+  }
+
+  abort("`preprocessor` must be a formula, recipe, or a set of workflow variables.")
 }
 
 # ------------------------------------------------------------------------------

--- a/man/workflow.Rd
+++ b/man/workflow.Rd
@@ -4,7 +4,18 @@
 \alias{workflow}
 \title{Create a workflow}
 \usage{
-workflow()
+workflow(preprocessor = NULL, spec = NULL)
+}
+\arguments{
+\item{preprocessor}{An optional preprocessor to add to the workflow. One of:
+\itemize{
+\item A formula, passed on to \code{\link[=add_formula]{add_formula()}}.
+\item A recipe, passed on to \code{\link[=add_recipe]{add_recipe()}}.
+\item A \code{\link[=workflow_variables]{workflow_variables()}} object, passed on to \code{\link[=add_variables]{add_variables()}}.
+}}
+
+\item{spec}{An optional parsnip model specification to add to the workflow.
+Passed on to \code{\link[=add_model]{add_model()}}.}
 }
 \value{
 A new \code{workflow} object.
@@ -14,6 +25,13 @@ A \code{workflow} is a container object that aggregates information required to
 fit and predict from a model. This information might be a recipe used in
 preprocessing, specified through \code{\link[=add_recipe]{add_recipe()}}, or the model specification
 to fit, specified through \code{\link[=add_model]{add_model()}}.
+
+The \code{preprocessor} and \code{spec} arguments allow you add components to a
+workflow quickly, without having to go through the \verb{add_*()} functions, such
+as \code{\link[=add_recipe]{add_recipe()}} or \code{\link[=add_model]{add_model()}}. However, if you need to control any of
+the optional arguments to those functions, such as the \code{blueprint} or the
+model \code{formula}, then you should use the \verb{add_*()} functions directly
+instead.
 }
 \section{Indicator Variable Details}{
 Some modeling functions in R create indicator/dummy variables from
@@ -133,28 +151,26 @@ data("attrition")
 model <- logistic_reg() \%>\%
   set_engine("glm")
 
-base_wf <- workflow() \%>\%
-  add_model(model)
+formula <- Attrition ~ BusinessTravel + YearsSinceLastPromotion + OverTime
 
-formula_wf <- base_wf \%>\%
-  add_formula(Attrition ~ BusinessTravel + YearsSinceLastPromotion + OverTime)
+wf_formula <- workflow(formula, model)
 
-fit(formula_wf, attrition)
+fit(wf_formula, attrition)
 
 recipe <- recipe(Attrition ~ ., attrition) \%>\%
   step_dummy(all_nominal(), -Attrition) \%>\%
   step_corr(all_predictors(), threshold = 0.8)
 
-recipe_wf <- base_wf \%>\%
-  add_recipe(recipe)
+wf_recipe <- workflow(recipe, model)
 
-fit(recipe_wf, attrition)
+fit(wf_recipe, attrition)
 
-variable_wf <- base_wf \%>\%
-  add_variables(
-    Attrition,
-    c(BusinessTravel, YearsSinceLastPromotion, OverTime)
-  )
+variables <- workflow_variables(
+  Attrition,
+  c(BusinessTravel, YearsSinceLastPromotion, OverTime)
+)
 
-fit(variable_wf, attrition)
+wf_variables <- workflow(variables, model)
+
+fit(wf_variables, attrition)
 }

--- a/tests/testthat/_snaps/workflow.md
+++ b/tests/testthat/_snaps/workflow.md
@@ -1,3 +1,17 @@
+# model spec is validated
+
+    Code
+      workflow(spec = 1)
+    Error <rlang_error>
+      `spec` must be a `model_spec`.
+
+# preprocessor is validated
+
+    Code
+      workflow(preprocessor = 1)
+    Error <rlang_error>
+      `preprocessor` must be a formula, recipe, or a set of workflow variables.
+
 # input must be a workflow
 
     `x` must be a workflow, not a numeric.

--- a/tests/testthat/test-workflow.R
+++ b/tests/testthat/test-workflow.R
@@ -28,6 +28,35 @@ test_that("workflow must be the first argument when adding actions", {
   expect_error(add_model(1, mod), "must be a workflow")
 })
 
+test_that("can add a model spec directly to a workflow", {
+  mod <- parsnip::linear_reg()
+  workflow <- workflow(spec = mod)
+
+  expect_identical(workflow$fit$actions$model$spec, mod)
+})
+
+test_that("can add a preprocessor directly to a workflow", {
+  preprocessor <- recipes::recipe(mpg ~ cyl, mtcars)
+  workflow <- workflow(preprocessor)
+  expect_identical(workflow$pre$actions$recipe$recipe, preprocessor)
+
+  preprocessor <- mpg ~ cyl
+  workflow <- workflow(preprocessor)
+  expect_identical(workflow$pre$actions$formula$formula, preprocessor)
+
+  preprocessor <- workflow_variables(mpg, cyl)
+  workflow <- workflow(preprocessor)
+  expect_identical(workflow$pre$actions$variables$variables, preprocessor)
+})
+
+test_that("model spec is validated", {
+  expect_snapshot(error = TRUE, workflow(spec = 1))
+})
+
+test_that("preprocessor is validated", {
+  expect_snapshot(error = TRUE, workflow(preprocessor = 1))
+})
+
 # ------------------------------------------------------------------------------
 # new_workflow()
 


### PR DESCRIPTION
Closes #108 
Closes #110 

This PR gives `workflow()` new `preprocessor` and `spec` arguments. These are optional, but allow users to easy add both model preprocessors and parsnip specifications in one line, rather than requiring the `add_*()` family of functions.

The preprocessor can be a recipe, formula, or `workflow_variables()` result.