### PR TITLE
Clean up the deprecation of the `pull_*()` functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # workflows (development version)
 
+* Internally cleaned up remaining usage of soft-deprecated `pull_*()` functions.
+
 # workflows 0.2.3
 
 * `workflow()` has gained new `preprocessor` and `spec` arguments for adding

--- a/R/extract.R
+++ b/R/extract.R
@@ -24,32 +24,34 @@
 #'    whether the fitted or original recipe is returned.
 #'
 #' @param x A workflow
+#'
 #' @param estimated A logical for whether the original (unfit) recipe or the
 #' fitted recipe should be returned. This argument should be named.
-#' @param ... Not currently used.
-#' @details
-#' These functions supersede the `pull_*()` functions.
 #'
+#' @param ... Not currently used.
+#'
+#' @details
 #' Extracting the underlying engine fit can be helpful for describing the
-#'  model (via `print()`, `summary()`, `plot()`, etc.) or for variable
-#'  importance/explainers.
+#' model (via `print()`, `summary()`, `plot()`, etc.) or for variable
+#' importance/explainers.
 #'
 #' However, users should not invoke the `predict()` method on an extracted
-#'  model. There may be preprocessing operations that `workflows` has executed on
-#'  the data prior to giving it to the model. Bypassing these can lead to errors
-#'  or silently generating incorrect predictions.
+#' model. There may be preprocessing operations that `workflows` has executed on
+#' the data prior to giving it to the model. Bypassing these can lead to errors
+#' or silently generating incorrect predictions.
 #'
 #' *Good*:
 #' ```r
-#'    workflow_fit %>% predict(new_data)
+#' workflow_fit %>% predict(new_data)
 #' ```
 #'
 #' *Bad*:
 #' ```r
-#'    workflow_fit %>% extract_fit_engine()  %>% predict(new_data)
-#'    # or
-#'    workflow_fit %>% extract_fit_parsnip() %>% predict(new_data)
+#' workflow_fit %>% extract_fit_engine()  %>% predict(new_data)
+#' # or
+#' workflow_fit %>% extract_fit_parsnip() %>% predict(new_data)
 #' ```
+#'
 #' @return
 #' The extracted value from the object, `x`, as described in the description
 #' section.

--- a/R/pull.R
+++ b/R/pull.R
@@ -4,7 +4,8 @@
 #'
 #' `r lifecycle::badge("soft-deprecated")`
 #'
-#' Please use the `extract_*()` functions instead of these (e.g. [extract_mold()]).
+#' Please use the `extract_*()` functions instead of these
+#' (e.g. [extract_mold()]).
 #'
 #' These functions extract various elements from a workflow object. If they do
 #' not exist yet, an error is thrown.
@@ -30,6 +31,7 @@
 #' section.
 #'
 #' @name workflow-extractors
+#' @keywords internal
 #' @examples
 #' library(parsnip)
 #' library(recipes)
@@ -81,78 +83,38 @@ NULL
 #' @export
 pull_workflow_preprocessor <- function(x) {
   lifecycle::deprecate_soft("0.2.3", "pull_workflow_preprocessor()", "extract_preprocessor()")
-
   validate_is_workflow(x)
-
-  if (has_preprocessor_formula(x)) {
-    return(x$pre$actions$formula$formula)
-  }
-
-  if (has_preprocessor_recipe(x)) {
-    return(x$pre$actions$recipe$recipe)
-  }
-
-  if (has_preprocessor_variables(x)) {
-    return(x$pre$actions$variables$variables)
-  }
-
-  abort("The workflow does not have a preprocessor.")
+  extract_preprocessor(x)
 }
 
 #' @rdname workflow-extractors
 #' @export
 pull_workflow_spec <- function(x) {
   lifecycle::deprecate_soft("0.2.3", "pull_workflow_spec()", "extract_spec_parsnip()")
-
   validate_is_workflow(x)
-
-  if (has_spec(x)) {
-    return(x$fit$actions$model$spec)
-  }
-
-  abort("The workflow does not have a model spec.")
+  extract_spec_parsnip(x)
 }
 
 #' @rdname workflow-extractors
 #' @export
 pull_workflow_fit <- function(x) {
   lifecycle::deprecate_soft("0.2.3", "pull_workflow_fit()", "extract_fit_parsnip()")
-
   validate_is_workflow(x)
-
-  if (has_fit(x)) {
-    return(x$fit$fit)
-  }
-
-  abort("The workflow does not have a model fit. Have you called `fit()` yet?")
+  extract_fit_parsnip(x)
 }
 
 #' @rdname workflow-extractors
 #' @export
 pull_workflow_mold <- function(x) {
   lifecycle::deprecate_soft("0.2.3", "pull_workflow_mold()", "extract_mold()")
-
   validate_is_workflow(x)
-
-  if (has_mold(x)) {
-    return(x$pre$mold)
-  }
-
-  abort("The workflow does not have a mold. Have you called `fit()` yet?")
+  extract_mold(x)
 }
 
 #' @rdname workflow-extractors
 #' @export
 pull_workflow_prepped_recipe <- function(x) {
   lifecycle::deprecate_soft("0.2.3", "pull_workflow_prepped_recipe()", "extract_recipe()")
-
   validate_is_workflow(x)
-
-  if (!has_preprocessor_recipe(x)) {
-    abort("The workflow must have a recipe preprocessor.")
-  }
-
-  mold <- pull_workflow_mold(x)
-
-  mold$blueprint$recipe
+  extract_recipe(x)
 }

--- a/man/add_formula.Rd
+++ b/man/add_formula.Rd
@@ -89,10 +89,9 @@ pre_encoded <- lm_wflow \%>\%
   fit(data = penguins)
 
 pre_encoded_parsnip_fit <- pre_encoded \%>\% 
-  pull_workflow_fit()
-}\if{html}{\out{</div>}}\preformatted{## Warning: `pull_workflow_fit()` was deprecated in workflows 0.2.3.
-## Please use `extract_fit_parsnip()` instead.
-}\if{html}{\out{<div class="r">}}\preformatted{pre_encoded_fit <- pre_encoded_parsnip_fit$fit
+  extract_fit_parsnip()
+
+pre_encoded_fit <- pre_encoded_parsnip_fit$fit
 
 # The `lm()` formula is *not* the same as the `add_formula()` formula: 
 pre_encoded_fit
@@ -139,10 +138,9 @@ un_encoded <- lm_wflow \%>\%
   fit(data = penguins)
 
 un_encoded_parsnip_fit <- un_encoded \%>\% 
-  pull_workflow_fit()
-}\if{html}{\out{</div>}}\preformatted{## Warning: `pull_workflow_fit()` was deprecated in workflows 0.2.3.
-## Please use `extract_fit_parsnip()` instead.
-}\if{html}{\out{<div class="r">}}\preformatted{un_encoded_fit <- un_encoded_parsnip_fit$fit
+  extract_fit_parsnip()
+
+un_encoded_fit <- un_encoded_parsnip_fit$fit
 
 un_encoded_fit
 }\if{html}{\out{</div>}}\preformatted{## 
@@ -190,10 +188,9 @@ custom_formula <- workflow() \%>\%
   fit(data = penguins)
 
 custom_parsnip_fit <- custom_formula \%>\% 
-  pull_workflow_fit()
-}\if{html}{\out{</div>}}\preformatted{## Warning: `pull_workflow_fit()` was deprecated in workflows 0.2.3.
-## Please use `extract_fit_parsnip()` instead.
-}\if{html}{\out{<div class="r">}}\preformatted{custom_fit <- custom_parsnip_fit$fit
+  extract_fit_parsnip()
+
+custom_fit <- custom_parsnip_fit$fit
 
 custom_fit
 }\if{html}{\out{</div>}}\preformatted{## 
@@ -216,11 +213,8 @@ custom_fit
 Finally, when a formula is updated or removed from a fitted workflow,
 the corresponding model fit is removed.\if{html}{\out{<div class="r">}}\preformatted{custom_formula_no_fit <- update_formula(custom_formula, body_mass_g ~ species)
 
-try(pull_workflow_fit(custom_formula_no_fit))
-}\if{html}{\out{</div>}}\preformatted{## Warning: `pull_workflow_fit()` was deprecated in workflows 0.2.3.
-## Please use `extract_fit_parsnip()` instead.
-
-## Error : The workflow does not have a model fit. Have you called `fit()` yet?
+try(extract_fit_parsnip(custom_formula_no_fit))
+}\if{html}{\out{</div>}}\preformatted{## Error : The workflow does not have a model fit. Have you called `fit()` yet?
 }
 }
 }

--- a/man/extract-workflow.Rd
+++ b/man/extract-workflow.Rd
@@ -54,8 +54,6 @@ whether the fitted or original recipe is returned.
 }
 }
 \details{
-These functions supersede the \verb{pull_*()} functions.
-
 Extracting the underlying engine fit can be helpful for describing the
 model (via \code{print()}, \code{summary()}, \code{plot()}, etc.) or for variable
 importance/explainers.
@@ -65,12 +63,12 @@ model. There may be preprocessing operations that \code{workflows} has executed 
 the data prior to giving it to the model. Bypassing these can lead to errors
 or silently generating incorrect predictions.
 
-\emph{Good}:\if{html}{\out{<div class="r">}}\preformatted{   workflow_fit \%>\% predict(new_data)
+\emph{Good}:\if{html}{\out{<div class="r">}}\preformatted{workflow_fit \%>\% predict(new_data)
 }\if{html}{\out{</div>}}
 
-\emph{Bad}:\if{html}{\out{<div class="r">}}\preformatted{   workflow_fit \%>\% extract_fit_engine()  \%>\% predict(new_data)
-   # or
-   workflow_fit \%>\% extract_fit_parsnip() \%>\% predict(new_data)
+\emph{Bad}:\if{html}{\out{<div class="r">}}\preformatted{workflow_fit \%>\% extract_fit_engine()  \%>\% predict(new_data)
+# or
+workflow_fit \%>\% extract_fit_parsnip() \%>\% predict(new_data)
 }\if{html}{\out{</div>}}
 }
 \examples{

--- a/man/rmd/add-formula.Rmd
+++ b/man/rmd/add-formula.Rmd
@@ -39,7 +39,7 @@ pre_encoded <- lm_wflow %>%
   fit(data = penguins)
 
 pre_encoded_parsnip_fit <- pre_encoded %>% 
-  pull_workflow_fit()
+  extract_fit_parsnip()
 
 pre_encoded_fit <- pre_encoded_parsnip_fit$fit
 
@@ -68,7 +68,7 @@ un_encoded <- lm_wflow %>%
   fit(data = penguins)
 
 un_encoded_parsnip_fit <- un_encoded %>% 
-  pull_workflow_fit()
+  extract_fit_parsnip()
 
 un_encoded_fit <- un_encoded_parsnip_fit$fit
 
@@ -100,7 +100,7 @@ custom_formula <- workflow() %>%
   fit(data = penguins)
 
 custom_parsnip_fit <- custom_formula %>% 
-  pull_workflow_fit()
+  extract_fit_parsnip()
 
 custom_fit <- custom_parsnip_fit$fit
 
@@ -114,5 +114,5 @@ Finally, when a formula is updated or removed from a fitted workflow, the corres
 ```{r remove}
 custom_formula_no_fit <- update_formula(custom_formula, body_mass_g ~ species)
 
-try(pull_workflow_fit(custom_formula_no_fit))
+try(extract_fit_parsnip(custom_formula_no_fit))
 ```

--- a/man/workflow-extractors.Rd
+++ b/man/workflow-extractors.Rd
@@ -29,7 +29,8 @@ section.
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#soft-deprecated}{\figure{lifecycle-soft-deprecated.svg}{options: alt='[Soft-deprecated]'}}}{\strong{[Soft-deprecated]}}
 
-Please use the \verb{extract_*()} functions instead of these (e.g. \code{\link[=extract_mold]{extract_mold()}}).
+Please use the \verb{extract_*()} functions instead of these
+(e.g. \code{\link[=extract_mold]{extract_mold()}}).
 
 These functions extract various elements from a workflow object. If they do
 not exist yet, an error is thrown.
@@ -91,3 +92,4 @@ identical(
   pull_workflow_prepped_recipe(fit_recipe_wf)
 )
 }
+\keyword{internal}

--- a/tests/testthat/_snaps/pull.md
+++ b/tests/testthat/_snaps/pull.md
@@ -1,0 +1,40 @@
+# `pull_workflow_preprocessor()` is soft-deprecated
+
+    Code
+      x <- pull_workflow_preprocessor(workflow)
+    Warning <lifecycle_warning_deprecated>
+      `pull_workflow_preprocessor()` was deprecated in workflows 0.2.3.
+      Please use `extract_preprocessor()` instead.
+
+# `pull_workflow_spec()` is soft-deprecated
+
+    Code
+      x <- pull_workflow_spec(workflow)
+    Warning <lifecycle_warning_deprecated>
+      `pull_workflow_spec()` was deprecated in workflows 0.2.3.
+      Please use `extract_spec_parsnip()` instead.
+
+# `pull_workflow_fit()` is soft-deprecated
+
+    Code
+      x <- pull_workflow_fit(workflow)
+    Warning <lifecycle_warning_deprecated>
+      `pull_workflow_fit()` was deprecated in workflows 0.2.3.
+      Please use `extract_fit_parsnip()` instead.
+
+# `pull_workflow_mold()` is soft-deprecated
+
+    Code
+      x <- pull_workflow_mold(workflow)
+    Warning <lifecycle_warning_deprecated>
+      `pull_workflow_mold()` was deprecated in workflows 0.2.3.
+      Please use `extract_mold()` instead.
+
+# `pull_workflow_prepped_recipe()` is soft-deprecated
+
+    Code
+      x <- pull_workflow_prepped_recipe(workflow)
+    Warning <lifecycle_warning_deprecated>
+      `pull_workflow_prepped_recipe()` was deprecated in workflows 0.2.3.
+      Please use `extract_recipe()` instead.
+

--- a/tests/testthat/helper-lifecycle.R
+++ b/tests/testthat/helper-lifecycle.R
@@ -1,0 +1,3 @@
+local_lifecycle_quiet <- function(frame = caller_env()) {
+  local_options(lifecycle_verbosity = "quiet", .frame = frame)
+}

--- a/tests/testthat/test-pre-action-variables.R
+++ b/tests/testthat/test-pre-action-variables.R
@@ -231,11 +231,11 @@ test_that("can update a formula", {
   wf3 <- update_variables(wf1, variables = workflow_variables(cyl, mpg))
 
   expect_identical(
-    pull_workflow_preprocessor(wf2),
+    extract_preprocessor(wf2),
     new_workflow_variables(outcomes = quo(cyl), predictors = quo(mpg))
   )
   expect_identical(
-    pull_workflow_preprocessor(wf3),
+    extract_preprocessor(wf3),
     new_workflow_variables(outcomes = quo(cyl), predictors = quo(mpg))
   )
 })

--- a/tests/testthat/test-pull.R
+++ b/tests/testthat/test-pull.R
@@ -2,6 +2,8 @@
 # pull_workflow_preprocessor()
 
 test_that("can pull a formula preprocessor", {
+  local_lifecycle_quiet()
+
   workflow <- workflow()
   workflow <- add_formula(workflow, mpg ~ cyl)
 
@@ -12,6 +14,8 @@ test_that("can pull a formula preprocessor", {
 })
 
 test_that("can pull a recipe preprocessor", {
+  local_lifecycle_quiet()
+
   recipe <- recipes::recipe(mpg ~ cyl, mtcars)
 
   workflow <- workflow()
@@ -24,6 +28,8 @@ test_that("can pull a recipe preprocessor", {
 })
 
 test_that("can pull a variables preprocessor", {
+  local_lifecycle_quiet()
+
   variables <- workflow_variables(mpg, c(cyl, disp))
 
   workflow <- workflow()
@@ -36,6 +42,8 @@ test_that("can pull a variables preprocessor", {
 })
 
 test_that("error if no preprocessor", {
+  local_lifecycle_quiet()
+
   expect_error(
     pull_workflow_preprocessor(workflow()),
     "does not have a preprocessor"
@@ -43,16 +51,27 @@ test_that("error if no preprocessor", {
 })
 
 test_that("error if not a workflow", {
+  local_lifecycle_quiet()
+
   expect_error(
     pull_workflow_preprocessor(1),
     "must be a workflow"
   )
 })
 
+test_that("`pull_workflow_preprocessor()` is soft-deprecated", {
+  workflow <- workflow()
+  workflow <- add_formula(workflow, mpg ~ cyl)
+
+  expect_snapshot(x <- pull_workflow_preprocessor(workflow))
+})
+
 # ------------------------------------------------------------------------------
 # pull_workflow_spec()
 
 test_that("can pull a model spec", {
+  local_lifecycle_quiet()
+
   model <- parsnip::linear_reg()
 
   workflow <- workflow()
@@ -65,6 +84,8 @@ test_that("can pull a model spec", {
 })
 
 test_that("error if no spec", {
+  local_lifecycle_quiet()
+
   expect_error(
     pull_workflow_spec(workflow()),
     "does not have a model spec"
@@ -72,16 +93,29 @@ test_that("error if no spec", {
 })
 
 test_that("error if not a workflow", {
+  local_lifecycle_quiet()
+
   expect_error(
     pull_workflow_spec(1),
     "must be a workflow"
   )
 })
 
+test_that("`pull_workflow_spec()` is soft-deprecated", {
+  model <- parsnip::linear_reg()
+
+  workflow <- workflow()
+  workflow <- add_model(workflow, model)
+
+  expect_snapshot(x <- pull_workflow_spec(workflow))
+})
+
 # ------------------------------------------------------------------------------
 # pull_workflow_fit()
 
 test_that("can pull a model fit", {
+  local_lifecycle_quiet()
+
   model <- parsnip::linear_reg()
   model <- parsnip::set_engine(model, "lm")
 
@@ -98,6 +132,8 @@ test_that("can pull a model fit", {
 })
 
 test_that("error if no fit", {
+  local_lifecycle_quiet()
+
   expect_error(
     pull_workflow_fit(workflow()),
     "does not have a model fit. Have you called `fit[(][)]` yet?"
@@ -105,16 +141,33 @@ test_that("error if no fit", {
 })
 
 test_that("error if not a workflow", {
+  local_lifecycle_quiet()
+
   expect_error(
     pull_workflow_fit(1),
     "must be a workflow"
   )
 })
 
+test_that("`pull_workflow_fit()` is soft-deprecated", {
+  model <- parsnip::linear_reg()
+  model <- parsnip::set_engine(model, "lm")
+
+  workflow <- workflow()
+  workflow <- add_model(workflow, model)
+  workflow <- add_formula(workflow, mpg ~ cyl)
+
+  workflow <- fit(workflow, mtcars)
+
+  expect_snapshot(x <- pull_workflow_fit(workflow))
+})
+
 # ------------------------------------------------------------------------------
 # pull_workflow_mold()
 
 test_that("can pull a mold", {
+  local_lifecycle_quiet()
+
   model <- parsnip::linear_reg()
   model <- parsnip::set_engine(model, "lm")
 
@@ -133,6 +186,8 @@ test_that("can pull a mold", {
 })
 
 test_that("error if no mold", {
+  local_lifecycle_quiet()
+
   expect_error(
     pull_workflow_mold(workflow()),
     "does not have a mold. Have you called `fit[(][)]` yet?"
@@ -140,16 +195,33 @@ test_that("error if no mold", {
 })
 
 test_that("error if not a workflow", {
+  local_lifecycle_quiet()
+
   expect_error(
     pull_workflow_mold(1),
     "must be a workflow"
   )
 })
 
+test_that("`pull_workflow_mold()` is soft-deprecated", {
+  model <- parsnip::linear_reg()
+  model <- parsnip::set_engine(model, "lm")
+
+  workflow <- workflow()
+  workflow <- add_model(workflow, model)
+  workflow <- add_formula(workflow, mpg ~ cyl)
+
+  workflow <- fit(workflow, mtcars)
+
+  expect_snapshot(x <- pull_workflow_mold(workflow))
+})
+
 # ------------------------------------------------------------------------------
 # pull_workflow_prepped_recipe()
 
 test_that("can pull a prepped recipe", {
+  local_lifecycle_quiet()
+
   model <- parsnip::linear_reg()
   model <- parsnip::set_engine(model, "lm")
 
@@ -170,6 +242,8 @@ test_that("can pull a prepped recipe", {
 })
 
 test_that("error if no recipe preprocessor", {
+  local_lifecycle_quiet()
+
   expect_error(
     pull_workflow_prepped_recipe(workflow()),
     "must have a recipe preprocessor"
@@ -177,6 +251,8 @@ test_that("error if no recipe preprocessor", {
 })
 
 test_that("error if no mold", {
+  local_lifecycle_quiet()
+
   recipe <- recipes::recipe(mpg ~ cyl, mtcars)
 
   workflow <- workflow()
@@ -189,8 +265,25 @@ test_that("error if no mold", {
 })
 
 test_that("error if not a workflow", {
+  local_lifecycle_quiet()
+
   expect_error(
     pull_workflow_prepped_recipe(1),
     "must be a workflow"
   )
+})
+
+test_that("`pull_workflow_prepped_recipe()` is soft-deprecated", {
+  model <- parsnip::linear_reg()
+  model <- parsnip::set_engine(model, "lm")
+
+  recipe <- recipes::recipe(mpg ~ cyl, mtcars)
+
+  workflow <- workflow()
+  workflow <- add_model(workflow, model)
+  workflow <- add_recipe(workflow, recipe)
+
+  workflow <- fit(workflow, mtcars)
+
+  expect_snapshot(x <- pull_workflow_prepped_recipe(workflow))
 })


### PR DESCRIPTION
Follow up from #109 to further clean up the soft-deprecation process