### PR TITLE
move method for `tunable()` from tune to workflows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workflows
 Title: Modeling Workflows
-Version: 0.2.4.9000
+Version: 0.2.4.9001
 Authors@R: 
     c(person(given = "Davis",
              family = "Vaughan",

--- a/R/generics.R
+++ b/R/generics.R
@@ -43,3 +43,17 @@ tune_args_workflow <- function(object, ...) {
   param_data
 }
 
+# Lazily registered in .onLoad()
+tunable_workflow <- function(x, ...) {
+  model <- extract_spec_parsnip(x)
+  param_data <- generics::tunable(model)
+
+  if (has_preprocessor_recipe(x)) {
+    recipe <- extract_preprocessor(x)
+    recipe_param_data <- generics::tunable(recipe)
+
+    param_data <- vctrs::vec_rbind(param_data, recipe_param_data)
+  }
+
+  param_data
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -20,6 +20,17 @@
     # `tune_args.workflow()` moved from tune to workflows
     vctrs::s3_register("generics::tune_args", "workflow", tune_args_workflow)
   }
+
+  should_register_tunable_method <- tryCatch(
+    expr = utils::packageVersion("tune") >= "0.1.6.9002",
+    error = function(cnd) TRUE
+  )
+
+  if (should_register_tunable_method) {
+    # `tunable.workflow()` moved from tune to workflows
+    vctrs::s3_register("generics::tunable", "workflow", tunable_workflow)
+  }
+
 }
 
 # nocov end

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -21,6 +21,8 @@
     vctrs::s3_register("generics::tune_args", "workflow", tune_args_workflow)
   }
 
+  # - If tune isn't installed, register the method (`packageVersion()` will error here)
+  # - If tune >= 0.1.6.9002 is installed, register the method
   should_register_tunable_method <- tryCatch(
     expr = utils::packageVersion("tune") >= "0.1.6.9002",
     error = function(cnd) TRUE


### PR DESCRIPTION
This PR is part of moving methods for `tunable()` from tune to the package which holds the corresponding object class:

* the methods for `recipe`, `step`, and `check` are already in recipes, that PR just cleans up the documentation. https://github.com/tidymodels/recipes/pull/856
* the methods for `model_spec` and various model types such as `linear_reg` etc are moved to parsnip https://github.com/tidymodels/parsnip/pull/606
* the method for `workflow` is moved to workflows (aka this PR here)

When methods have been moved, the methods are registered conditionally on the version of tune from which they have been removed. The tune PR is https://github.com/tidymodels/tune/pull/433

The tests require multiple packages so they are all in extratests: https://github.com/tidymodels/extratests/pull/34

The PR on extratests should be merged first, then the ones on recipes and parsnip, then workflows, then tune.

This is part of the wider aim of introducing `extract_parameter_dials()` and `extract_parameter_set_dials()` and the next steps are:

* introducing `extract_parameter_set_dials()`
* introducing `extract_parameter_dials()`
* moving the methods for `parameters()` similar to this PR set
* updating documentation and learning materials
