### PR TITLE
Upkeep package versions and snapshots

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,23 +20,23 @@ Depends:
 Imports: 
     cli (>= 2.0.0),
     ellipsis (>= 0.2.0),
-    generics (>= 0.1.0.9000),
+    generics (>= 0.1.2),
     glue,
-    hardhat (>= 0.1.6.9001),
+    hardhat (>= 0.2.0),
     lifecycle (>= 1.0.0),
     purrr,
     parsnip (>= 0.1.7.9005),
-    rlang (>= 0.4.1),
-    tidyselect (>= 1.1.0),
-    vctrs (>= 0.3.6)
+    rlang (>= 1.0.1),
+    tidyselect (>= 1.1.2),
+    vctrs (>= 0.3.8)
 Suggests: 
     butcher (>= 0.1.3),
     covr,
-    dials (>= 0.0.10.9001),
+    dials (>= 0.1.0),
     knitr,
     magrittr,
     modeldata (>= 0.0.2),
-    recipes (>= 0.1.17.9001),
+    recipes (>= 0.2.0),
     rmarkdown,
     testthat (>= 3.0.0)
 VignetteBuilder: 
@@ -46,20 +46,13 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
 Config/testthat/edition: 3
 Config/Needs/website:
-    tidymodels/dials,
-    tidymodels/discrim,
     dplyr,
     earth,
     ggplot2,
-    tidymodels/hardhat,
     mda,
-    tidymodels/parsnip,
-    tidymodels/recipes,
+    tidymodels/discrim,
     tidyr,
     tidyverse/tidytemplate,
     yardstick
 Remotes: 
-    tidymodels/dials,
-    tidymodels/hardhat,
-    tidymodels/parsnip,
-    tidymodels/recipes
+    tidymodels/parsnip

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,19 +1,17 @@
 Package: workflows
 Title: Modeling Workflows
 Version: 0.2.4.9002
-Authors@R: 
-    c(person(given = "Davis",
-             family = "Vaughan",
-             role = c("aut", "cre"),
-             email = "davis@rstudio.com"),
-      person(given = "RStudio",
-             role = "cph"))
+Authors@R: c(
+    person("Davis", "Vaughan", , "davis@rstudio.com", role = c("aut", "cre")),
+    person("RStudio", role = "cph")
+  )
 Description: Managing both a 'parsnip' model and a preprocessor, such as a
-    model formula or recipe from 'recipes', can often be challenging. The goal
-    of 'workflows' is to streamline this process by bundling the model alongside
-    the preprocessor, all within the same object.
+    model formula or recipe from 'recipes', can often be challenging. The
+    goal of 'workflows' is to streamline this process by bundling the
+    model alongside the preprocessor, all within the same object.
 License: MIT + file LICENSE
-URL: https://github.com/tidymodels/workflows, https://workflows.tidymodels.org
+URL: https://github.com/tidymodels/workflows,
+    https://workflows.tidymodels.org
 BugReports: https://github.com/tidymodels/workflows/issues
 Depends: 
     R (>= 3.2)
@@ -24,8 +22,8 @@ Imports:
     glue,
     hardhat (>= 0.2.0),
     lifecycle (>= 1.0.0),
-    purrr,
     parsnip (>= 0.1.7.9005),
+    purrr,
     rlang (>= 1.0.1),
     tidyselect (>= 1.1.2),
     vctrs (>= 0.3.8)
@@ -41,10 +39,8 @@ Suggests:
     testthat (>= 3.0.0)
 VignetteBuilder: 
     knitr
-Encoding: UTF-8
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
-Config/testthat/edition: 3
+Remotes: 
+    tidymodels/parsnip
 Config/Needs/website:
     dplyr,
     earth,
@@ -54,5 +50,7 @@ Config/Needs/website:
     tidyr,
     tidyverse/tidytemplate,
     yardstick
-Remotes: 
-    tidymodels/parsnip
+Config/testthat/edition: 3
+Encoding: UTF-8
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,6 @@
 * New `extract_parameter_set_dials()` and `extract_parameter_dials()` methods 
   to extract parameter sets and single parameters from `workflow` objects.
 
-
 # workflows 0.2.4
 
 * `add_model()` and `update_model()` now use `...` to separate the required

--- a/man/add_formula.Rd
+++ b/man/add_formula.Rd
@@ -214,7 +214,8 @@ Finally, when a formula is updated or removed from a fitted workflow,
 the corresponding model fit is removed.\if{html}{\out{<div class="sourceCode r">}}\preformatted{custom_formula_no_fit <- update_formula(custom_formula, body_mass_g ~ species)
 
 try(extract_fit_parsnip(custom_formula_no_fit))
-}\if{html}{\out{</div>}}\preformatted{## Error : The workflow does not have a model fit. Have you called `fit()` yet?
+}\if{html}{\out{</div>}}\preformatted{## Error in extract_fit_parsnip(custom_formula_no_fit) : 
+##   The workflow does not have a model fit. Have you called `fit()` yet?
 }
 }
 }

--- a/tests/testthat/_snaps/extract.md
+++ b/tests/testthat/_snaps/extract.md
@@ -2,12 +2,10 @@
 
     Code
       extract_recipe(workflow, FALSE)
-    Error <rlib_error_dots_nonempty>
-      `...` is not empty.
-      
-      We detected these problematic arguments:
-      * `..1`
-      
-      These dots only exist to allow future extensions and should be empty.
-      Did you misspecify an argument?
+    Condition
+      Error in `extract_recipe()`:
+      ! `...` must be empty.
+      x Problematic argument:
+      * ..1 = FALSE
+      i Did you forget to name an argument?
 

--- a/tests/testthat/_snaps/pull.md
+++ b/tests/testthat/_snaps/pull.md
@@ -2,7 +2,8 @@
 
     Code
       x <- pull_workflow_preprocessor(workflow)
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       `pull_workflow_preprocessor()` was deprecated in workflows 0.2.3.
       Please use `extract_preprocessor()` instead.
 
@@ -10,7 +11,8 @@
 
     Code
       x <- pull_workflow_spec(workflow)
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       `pull_workflow_spec()` was deprecated in workflows 0.2.3.
       Please use `extract_spec_parsnip()` instead.
 
@@ -18,7 +20,8 @@
 
     Code
       x <- pull_workflow_fit(workflow)
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       `pull_workflow_fit()` was deprecated in workflows 0.2.3.
       Please use `extract_fit_parsnip()` instead.
 
@@ -26,7 +29,8 @@
 
     Code
       x <- pull_workflow_mold(workflow)
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       `pull_workflow_mold()` was deprecated in workflows 0.2.3.
       Please use `extract_mold()` instead.
 
@@ -34,7 +38,8 @@
 
     Code
       x <- pull_workflow_prepped_recipe(workflow)
-    Warning <lifecycle_warning_deprecated>
+    Condition
+      Warning:
       `pull_workflow_prepped_recipe()` was deprecated in workflows 0.2.3.
       Please use `extract_recipe()` instead.
 

--- a/tests/testthat/_snaps/workflow.md
+++ b/tests/testthat/_snaps/workflow.md
@@ -2,15 +2,17 @@
 
     Code
       workflow(spec = 1)
-    Error <rlang_error>
-      `spec` must be a `model_spec`.
+    Condition
+      Error in `new_action_model()`:
+      ! `spec` must be a `model_spec`.
 
 # preprocessor is validated
 
     Code
       workflow(preprocessor = 1)
-    Error <rlang_error>
-      `preprocessor` must be a formula, recipe, or a set of workflow variables.
+    Condition
+      Error in `add_preprocessor()`:
+      ! `preprocessor` must be a formula, recipe, or a set of workflow variables.
 
 # input must be a workflow
 


### PR DESCRIPTION
- Update version requirements now that Remotes are on CRAN
- Bump dependency requirements (like rlang, vctrs, and tidyselect which may affect snapshots)
- Update snapshots and documentation to new rlang (with the intention to pass the call through later)