### PR TITLE
Pass the error call through to `abort()`

### DIFF
--- a/R/action.R
+++ b/R/action.R
@@ -1,7 +1,7 @@
 add_action <- function(x, action, name, ..., call = caller_env()) {
   validate_is_workflow(x, call = call)
 
-  check_conflicts(action, x)
+  check_conflicts(action, x, call = call)
 
   add_action_impl(x, action, name)
 }
@@ -44,11 +44,12 @@ add_action_to_stage <- function(stage, action, name) {
 # with the current action. For instance, we can't have a formula action with
 # a recipe action
 
-check_conflicts <- function(action, x) {
+check_conflicts <- function(action, x, ..., call = caller_env()) {
+  check_dots_empty()
   UseMethod("check_conflicts")
 }
 
-check_conflicts.default <- function(action, x) {
+check_conflicts.default <- function(action, x, ..., call = caller_env()) {
   invisible(action)
 }
 

--- a/R/action.R
+++ b/R/action.R
@@ -100,7 +100,7 @@ new_action <- function(..., subclass = character()) {
   data <- list2(...)
 
   if (!is_uniquely_named(data)) {
-    abort("All elements of `...` must be uniquely named.")
+    abort("All elements of `...` must be uniquely named.", .internal = TRUE)
   }
 
   structure(data, class = c(subclass, "action"))

--- a/R/action.R
+++ b/R/action.R
@@ -1,7 +1,5 @@
-add_action <- function(x, action, name) {
-  if (!is_workflow(x)) {
-    abort("`x` must be a workflow.")
-  }
+add_action <- function(x, action, name, ..., call = caller_env()) {
+  validate_is_workflow(x, call = call)
 
   check_conflicts(action, x)
 
@@ -10,24 +8,25 @@ add_action <- function(x, action, name) {
 
 # ------------------------------------------------------------------------------
 
-add_action_impl <- function(x, action, name) {
+add_action_impl <- function(x, action, name, ..., call = caller_env()) {
+  check_dots_empty()
   UseMethod("add_action_impl", action)
 }
 
-add_action_impl.action_pre <- function(x, action, name) {
-  check_singleton(x$pre$actions, name)
+add_action_impl.action_pre <- function(x, action, name, ..., call = caller_env()) {
+  check_singleton(x$pre$actions, name, call = call)
   x$pre <- add_action_to_stage(x$pre, action, name)
   x
 }
 
-add_action_impl.action_fit <- function(x, action, name) {
-  check_singleton(x$fit$actions, name)
+add_action_impl.action_fit <- function(x, action, name, ..., call = caller_env()) {
+  check_singleton(x$fit$actions, name, call = call)
   x$fit <- add_action_to_stage(x$fit, action, name)
   x
 }
 
-add_action_impl.action_post <- function(x, action, name) {
-  check_singleton(x$post$actions, name)
+add_action_impl.action_post <- function(x, action, name, ..., call = caller_env()) {
+  check_singleton(x$post$actions, name, call = call)
   x$post <- add_action_to_stage(x$post, action, name)
   x
 }
@@ -55,10 +54,13 @@ check_conflicts.default <- function(action, x) {
 
 # ------------------------------------------------------------------------------
 
-check_singleton <- function(actions, name) {
+check_singleton <- function(actions, name, ..., call = caller_env()) {
+  check_dots_empty()
+
   if (name %in% names(actions)) {
-    glubort("A `{name}` action has already been added to this workflow.")
+    glubort("A `{name}` action has already been added to this workflow.", .call = call)
   }
+
   invisible(actions)
 }
 

--- a/R/action.R
+++ b/R/action.R
@@ -3,7 +3,7 @@ add_action <- function(x, action, name, ..., call = caller_env()) {
 
   check_conflicts(action, x, call = call)
 
-  add_action_impl(x, action, name)
+  add_action_impl(x, action, name, call = call)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/broom.R
+++ b/R/broom.R
@@ -35,7 +35,7 @@ tidy.workflow <- function(x, what = "model", ...) {
     return(out)
   }
 
-  abort("Internal error: `what` must be 'model' or 'recipe'.")
+  abort("`what` must be 'model' or 'recipe'.", .internal = TRUE)
 }
 
 # ------------------------------------------------------------------------------

--- a/R/butcher.R
+++ b/R/butcher.R
@@ -100,8 +100,10 @@ add_butcher_class <- function(x) {
 # predictors/outcomes when butchering. This does a direct replacement, with
 # no resetting of `trained` or any stages.
 
-replace_workflow_preprocessor <- function(x, value) {
-  validate_is_workflow(x)
+replace_workflow_preprocessor <- function(x, value, ..., call = caller_env()) {
+  check_dots_empty()
+
+  validate_is_workflow(x, call = call)
 
   if (has_preprocessor_formula(x)) {
     x$pre$actions$formula$formula <- value
@@ -116,8 +118,10 @@ replace_workflow_preprocessor <- function(x, value) {
   x
 }
 
-replace_workflow_fit <- function(x, value) {
-  validate_is_workflow(x)
+replace_workflow_fit <- function(x, value, ..., call = caller_env()) {
+  check_dots_empty()
+
+  validate_is_workflow(x, call = call)
 
   if (!has_fit(x)) {
     abort("The workflow does not have a model fit. Have you called `fit()` yet?")
@@ -128,42 +132,50 @@ replace_workflow_fit <- function(x, value) {
   x
 }
 
-replace_workflow_predictors <- function(x, value) {
-  validate_is_workflow(x)
+replace_workflow_predictors <- function(x, value, ..., call = caller_env()) {
+  check_dots_empty()
+
+  validate_is_workflow(x, call = call)
 
   mold <- extract_mold(x)
   mold$predictors <- value
 
-  replace_workflow_mold(x, mold)
+  replace_workflow_mold(x, mold, call = call)
 }
 
-replace_workflow_outcomes <- function(x, value) {
-  validate_is_workflow(x)
+replace_workflow_outcomes <- function(x, value, ..., call = caller_env()) {
+  check_dots_empty()
+
+  validate_is_workflow(x, call = call)
 
   mold <- extract_mold(x)
   mold$outcomes <- value
 
-  replace_workflow_mold(x, mold)
+  replace_workflow_mold(x, mold, call = call)
 }
 
-replace_workflow_prepped_recipe <- function(x, value) {
-  validate_is_workflow(x)
+replace_workflow_prepped_recipe <- function(x, value, ..., call = caller_env()) {
+  check_dots_empty()
+
+  validate_is_workflow(x, call = call)
 
   if (!has_preprocessor_recipe(x)) {
-    abort("The workflow must have a recipe preprocessor.")
+    abort("The workflow must have a recipe preprocessor.", call = call)
   }
 
   mold <- extract_mold(x)
   mold$blueprint$recipe <- value
 
-  replace_workflow_mold(x, mold)
+  replace_workflow_mold(x, mold, call = call)
 }
 
-replace_workflow_mold <- function(x, value) {
-  validate_is_workflow(x)
+replace_workflow_mold <- function(x, value, ..., call = caller_env()) {
+  check_dots_empty()
+
+  validate_is_workflow(x, call = call)
 
   if (!has_mold(x)) {
-    abort("The workflow does not have a mold. Have you called `fit()` yet?")
+    abort("The workflow does not have a mold. Have you called `fit()` yet?", call = call)
   }
 
   x$pre$mold <- value

--- a/R/butcher.R
+++ b/R/butcher.R
@@ -112,7 +112,7 @@ replace_workflow_preprocessor <- function(x, value, ..., call = caller_env()) {
   } else if (has_preprocessor_variables(x)) {
     x$pre$actions$variables$variables <- value
   } else {
-    abort("The workflow does not have a preprocessor.")
+    abort("The workflow does not have a preprocessor.", call = call)
   }
 
   x
@@ -124,7 +124,10 @@ replace_workflow_fit <- function(x, value, ..., call = caller_env()) {
   validate_is_workflow(x, call = call)
 
   if (!has_fit(x)) {
-    abort("The workflow does not have a model fit. Have you called `fit()` yet?")
+    abort(
+      "The workflow does not have a model fit. Have you called `fit()` yet?",
+      call = call
+    )
   }
 
   x$fit$fit <- value

--- a/R/control.R
+++ b/R/control.R
@@ -27,13 +27,15 @@ print.control_workflow <- function(x, ...) {
   invisible()
 }
 
-check_control_parsnip <- function(x) {
+check_control_parsnip <- function(x, ..., call = caller_env()) {
+  check_dots_empty()
+
   if (is.null(x)) {
     x <- parsnip::control_parsnip()
   }
 
   if (!inherits(x, "control_parsnip")) {
-    abort("`control_parsnip` must be a 'control_parsnip' object.")
+    abort("`control_parsnip` must be a 'control_parsnip' object.", call = call)
   }
 
   x

--- a/R/fit-action-model.R
+++ b/R/fit-action-model.R
@@ -106,7 +106,7 @@ fit.action_model <- function(object, workflow, control) {
   mold <- workflow$pre$mold
 
   if (is.null(mold)) {
-    abort("Internal error: No mold exists. `workflow` pre stage has not been run.")
+    abort("No mold exists. `workflow` pre stage has not been run.", .internal = TRUE)
   }
 
   if (is.null(formula)) {

--- a/R/fit-action-model.R
+++ b/R/fit-action-model.R
@@ -132,13 +132,15 @@ fit_from_formula <- function(spec, mold, control_parsnip, formula) {
 
 # ------------------------------------------------------------------------------
 
-new_action_model <- function(spec, formula) {
+new_action_model <- function(spec, formula, ..., call = caller_env()) {
+  check_dots_empty()
+
   if (!is_model_spec(spec)) {
-    abort("`spec` must be a `model_spec`.")
+    abort("`spec` must be a `model_spec`.", call = call)
   }
 
   if (!is.null(formula) && !is_formula(formula)) {
-    abort("`formula` must be a formula, or `NULL`.")
+    abort("`formula` must be a formula, or `NULL`.", call = call)
   }
 
   new_action_fit(spec = spec, formula = formula, subclass = "action_model")

--- a/R/fit.R
+++ b/R/fit.R
@@ -180,13 +180,16 @@ validate_has_preprocessor <- function(x, ..., call = caller_env()) {
   invisible(x)
 }
 
-validate_has_model <- function(x) {
+validate_has_model <- function(x, ..., call = caller_env()) {
+  check_dots_empty()
+
   has_model <- has_action(x$fit, "model")
 
   if (!has_model) {
     glubort(
       "The workflow must have a model. ",
-      "Provide one with `add_model()`."
+      "Provide one with `add_model()`.",
+      .call = call
     )
   }
 

--- a/R/fit.R
+++ b/R/fit.R
@@ -161,7 +161,9 @@ fit.workflow <- function(object, data, ..., control = control_workflow()) {
 
 # ------------------------------------------------------------------------------
 
-validate_has_preprocessor <- function(x) {
+validate_has_preprocessor <- function(x, ..., call = caller_env()) {
+  check_dots_empty()
+
   has_preprocessor <-
     has_preprocessor_formula(x) ||
     has_preprocessor_recipe(x) ||
@@ -170,7 +172,8 @@ validate_has_preprocessor <- function(x) {
   if (!has_preprocessor) {
     glubort(
       "The workflow must have formula, recipe, or variables preprocessor. ",
-      "Provide one with `add_formula()`, `add_recipe()`, or `add_variables()`."
+      "Provide one with `add_formula()`, `add_recipe()`, or `add_variables()`.",
+      .call = call
     )
   }
 

--- a/R/fit.R
+++ b/R/fit.R
@@ -205,7 +205,7 @@ finalize_blueprint <- function(workflow) {
   } else if (has_preprocessor_variables(workflow)) {
     finalize_blueprint_variables(workflow)
   } else {
-    abort("Internal error: `workflow` should have a preprocessor at this point.")
+    abort("`workflow` should have a preprocessor at this point.", .internal = TRUE)
   }
 }
 
@@ -225,10 +225,10 @@ finalize_blueprint_formula <- function(workflow) {
   intercept <- tbl_encodings$compute_intercept
 
   if (!is_string(indicators)) {
-    abort("Internal error: `indicators` encoding from parsnip should be a string.")
+    abort("`indicators` encoding from parsnip should be a string.", .internal = TRUE)
   }
   if (!is_bool(intercept)) {
-    abort("Internal error: `intercept` encoding from parsnip should be a bool.")
+    abort("`intercept` encoding from parsnip should be a bool.", .internal = TRUE)
   }
 
   # Use model specific information to construct the blueprint
@@ -255,7 +255,7 @@ pull_workflow_spec_encoding_tbl <- function(workflow) {
   out <- tbl_encodings[indicator_spec, , drop = FALSE]
 
   if (nrow(out) != 1L) {
-    abort("Internal error: Exactly 1 model/engine/mode combination must be located.")
+    abort("Exactly 1 model/engine/mode combination must be located.", .internal = TRUE)
   }
 
   out

--- a/R/pre-action-formula.R
+++ b/R/pre-action-formula.R
@@ -97,14 +97,14 @@ fit.action_formula <- function(object, workflow, data) {
 
 # ------------------------------------------------------------------------------
 
-check_conflicts.action_formula <- function(action, x) {
+check_conflicts.action_formula <- function(action, x, ..., call = caller_env()) {
   pre <- x$pre
 
   if (has_action(pre, "recipe")) {
-    abort("A formula cannot be added when a recipe already exists.")
+    abort("A formula cannot be added when a recipe already exists.", call = call)
   }
   if (has_action(pre, "variables")) {
-    abort("A formula cannot be added when variables already exist.")
+    abort("A formula cannot be added when variables already exist.", call = call)
   }
 
   invisible(action)

--- a/R/pre-action-formula.R
+++ b/R/pre-action-formula.R
@@ -112,14 +112,16 @@ check_conflicts.action_formula <- function(action, x, ..., call = caller_env()) 
 
 # ------------------------------------------------------------------------------
 
-new_action_formula <- function(formula, blueprint) {
+new_action_formula <- function(formula, blueprint, ..., call = caller_env()) {
+  check_dots_empty()
+
   if (!is_formula(formula)) {
-    abort("`formula` must be a formula.")
+    abort("`formula` must be a formula.", call = call)
   }
 
   # `NULL` blueprints are finalized at fit time
   if (!is_null(blueprint) && !is_formula_blueprint(blueprint)) {
-    abort("`blueprint` must be a hardhat 'formula_blueprint'.")
+    abort("`blueprint` must be a hardhat 'formula_blueprint'.", call = call)
   }
 
   new_action_pre(

--- a/R/pre-action-recipe.R
+++ b/R/pre-action-recipe.R
@@ -110,14 +110,16 @@ check_conflicts.action_recipe <- function(action, x, ..., call = caller_env()) {
 
 # ------------------------------------------------------------------------------
 
-new_action_recipe <- function(recipe, blueprint) {
+new_action_recipe <- function(recipe, blueprint, ..., call = caller_env()) {
+  check_dots_empty()
+
   if (!is_recipe(recipe)) {
-    abort("`recipe` must be a recipe.")
+    abort("`recipe` must be a recipe.", call = call)
   }
 
   # `NULL` blueprints are finalized at fit time
   if (!is_null(blueprint) && !is_recipe_blueprint(blueprint)) {
-    abort("`blueprint` must be a hardhat 'recipe_blueprint'.")
+    abort("`blueprint` must be a hardhat 'recipe_blueprint'.", call = call)
   }
 
   new_action_pre(

--- a/R/pre-action-recipe.R
+++ b/R/pre-action-recipe.R
@@ -95,14 +95,14 @@ fit.action_recipe <- function(object, workflow, data) {
 
 # ------------------------------------------------------------------------------
 
-check_conflicts.action_recipe <- function(action, x) {
+check_conflicts.action_recipe <- function(action, x, ..., call = caller_env()) {
   pre <- x$pre
 
   if (has_action(pre, "formula")) {
-    abort("A recipe cannot be added when a formula already exists.")
+    abort("A recipe cannot be added when a formula already exists.", call = call)
   }
   if (has_action(pre, "variables")) {
-    abort("A recipe cannot be added when variables already exist.")
+    abort("A recipe cannot be added when variables already exist.", call = call)
   }
 
   invisible(action)

--- a/R/pre-action-variables.R
+++ b/R/pre-action-variables.R
@@ -218,10 +218,12 @@ check_conflicts.action_variables <- function(action, x, ..., call = caller_env()
 
 # ------------------------------------------------------------------------------
 
-new_action_variables <- function(variables, blueprint) {
+new_action_variables <- function(variables, blueprint, ..., call = caller_env()) {
+  check_dots_empty()
+
   # `NULL` blueprints are finalized at fit time
   if (!is_null(blueprint) && !is_xy_blueprint(blueprint)) {
-    abort("`blueprint` must be a hardhat 'xy_blueprint'.")
+    abort("`blueprint` must be a hardhat 'xy_blueprint'.", call = call)
   }
 
   new_action_pre(

--- a/R/pre-action-variables.R
+++ b/R/pre-action-variables.R
@@ -253,10 +253,10 @@ workflow_variables <- function(outcomes, predictors) {
 
 new_workflow_variables <- function(outcomes, predictors) {
   if (!is_quosure(outcomes)) {
-    abort("`outcomes` must be a quosure.")
+    abort("`outcomes` must be a quosure.", .internal = TRUE)
   }
   if (!is_quosure(predictors)) {
-    abort("`predictors` must be a quosure.")
+    abort("`predictors` must be a quosure.", .internal = TRUE)
   }
 
   data <- list(

--- a/R/pre-action-variables.R
+++ b/R/pre-action-variables.R
@@ -203,14 +203,14 @@ fit.action_variables <- function(object, workflow, data) {
 
 # ------------------------------------------------------------------------------
 
-check_conflicts.action_variables <- function(action, x) {
+check_conflicts.action_variables <- function(action, x, ..., call = caller_env()) {
   pre <- x$pre
 
   if (has_action(pre, "recipe")) {
-    abort("Variables cannot be added when a recipe already exists.")
+    abort("Variables cannot be added when a recipe already exists.", call = call)
   }
   if (has_action(pre, "formula")) {
-    abort("Variables cannot be added when a formula already exists.")
+    abort("Variables cannot be added when a formula already exists.", call = call)
   }
 
   invisible(action)

--- a/R/stage.R
+++ b/R/stage.R
@@ -1,6 +1,6 @@
 new_stage_pre <- function(actions = list(), mold = NULL) {
   if (!is.null(mold) && !is.list(mold)) {
-    abort("`mold` must be a result of calling `hardhat::mold()`.")
+    abort("`mold` must be a result of calling `hardhat::mold()`.", .internal = TRUE)
   }
 
   new_stage(actions = actions, mold = mold, subclass = "stage_pre")
@@ -8,7 +8,7 @@ new_stage_pre <- function(actions = list(), mold = NULL) {
 
 new_stage_fit <- function(actions = list(), fit = NULL) {
   if (!is.null(fit) && !is_model_fit(fit)) {
-    abort("`fit` must be a `model_fit`.")
+    abort("`fit` must be a `model_fit`.", .internal = TRUE)
   }
 
   new_stage(actions = actions, fit = fit, subclass = "stage_fit")
@@ -29,17 +29,17 @@ new_stage_post <- function(actions = list()) {
 
 new_stage <- function(actions = list(), ..., subclass = character()) {
   if (!is_list_of_actions(actions)) {
-    abort("`actions` must be a list of actions.")
+    abort("`actions` must be a list of actions.", .internal = TRUE)
   }
 
   if (!is_uniquely_named(actions)) {
-    abort("`actions` must be uniquely named.")
+    abort("`actions` must be uniquely named.", .internal = TRUE)
   }
 
   fields <- list2(...)
 
   if (!is_uniquely_named(fields)) {
-    abort("`...` must be uniquely named.")
+    abort("`...` must be uniquely named.", .internal = TRUE)
   }
 
   fields <- list2(actions = actions, !!! fields)

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,8 +6,8 @@ is_uniquely_named <- function(x) {
   }
 }
 
-glubort <- function (..., .sep = "", .envir = parent.frame()) {
-  abort(glue::glue(..., .sep = .sep, .envir = .envir))
+glubort <- function (..., .sep = "", .envir = caller_env(), .call = .envir) {
+  abort(glue::glue(..., .sep = .sep, .envir = .envir), call = .call)
 }
 
 is_model_fit <- function(x) {
@@ -46,9 +46,11 @@ vec_index_is_empty <- function (x) {
 
 # ------------------------------------------------------------------------------
 
-validate_is_workflow <- function(x, arg = "`x`") {
+validate_is_workflow <- function(x, ..., arg = "`x`", call = caller_env()) {
+  check_dots_empty()
+
   if (!is_workflow(x)) {
-    glubort("{arg} must be a workflow, not a {class(x)[[1]]}.")
+    glubort("{arg} must be a workflow, not a {class(x)[[1]]}.", .call = call)
   }
 
   invisible(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -88,6 +88,6 @@ has_blueprint <- function(x) {
   } else if (has_preprocessor_variables(x)) {
     !is.null(x$pre$actions$variables$blueprint)
   } else {
-    abort("Internal error: `x` must have a preprocessor to check for a blueprint.")
+    abort("`x` must have a preprocessor to check for a blueprint.", .internal = TRUE)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,12 +18,13 @@ is_model_spec <- function(x) {
   inherits(x, "model_spec")
 }
 
-validate_recipes_available <- function() {
+validate_recipes_available <- function(..., call = caller_env()) {
+  check_dots_empty()
+
   if (!requireNamespace("recipes", quietly = TRUE)) {
-    abort(
-      "The `recipes` package must be available to add a recipe."
-    )
+    abort("The `recipes` package must be available to add a recipe.", call = call)
   }
+
   invisible()
 }
 

--- a/R/workflow.R
+++ b/R/workflow.R
@@ -74,7 +74,9 @@ workflow <- function(preprocessor = NULL, spec = NULL) {
   out
 }
 
-add_preprocessor <- function(x, preprocessor) {
+add_preprocessor <- function(x, preprocessor, ..., call = caller_env()) {
+  check_dots_empty()
+
   if (is_formula(preprocessor)) {
     return(add_formula(x, preprocessor))
   }
@@ -87,7 +89,10 @@ add_preprocessor <- function(x, preprocessor) {
     return(add_variables(x, variables = preprocessor))
   }
 
-  abort("`preprocessor` must be a formula, recipe, or a set of workflow variables.")
+  abort(
+    "`preprocessor` must be a formula, recipe, or a set of workflow variables.",
+    call = call
+  )
 }
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/_snaps/broom.md
+++ b/tests/testthat/_snaps/broom.md
@@ -1,3 +1,27 @@
+# can't tidy the model of an unfit workflow
+
+    Code
+      tidy(x)
+    Condition
+      Error in `extract_fit_parsnip()`:
+      ! The workflow does not have a model fit. Have you called `fit()` yet?
+
+# can't tidy the recipe of an unfit workflow
+
+    Code
+      tidy(x, what = "recipe")
+    Condition
+      Error in `extract_recipe()`:
+      ! The workflow must have a recipe preprocessor.
+
+---
+
+    Code
+      tidy(x, what = "recipe")
+    Condition
+      Error in `extract_mold()`:
+      ! The workflow does not have a mold. Have you called `fit()` yet?
+
 # can't glance at the model of an unfit workflow
 
     The workflow does not have a model fit. Have you called `fit()` yet?

--- a/tests/testthat/_snaps/butcher.md
+++ b/tests/testthat/_snaps/butcher.md
@@ -1,0 +1,8 @@
+# fails if not a fitted workflow
+
+    Code
+      butcher::butcher(workflow())
+    Condition
+      Error in `extract_fit_parsnip()`:
+      ! The workflow does not have a model fit. Have you called `fit()` yet?
+

--- a/tests/testthat/_snaps/control.md
+++ b/tests/testthat/_snaps/control.md
@@ -1,0 +1,8 @@
+# parsnip control is validated
+
+    Code
+      control_workflow(control_parsnip = 1)
+    Condition
+      Error in `control_workflow()`:
+      ! `control_parsnip` must be a 'control_parsnip' object.
+

--- a/tests/testthat/_snaps/extract.md
+++ b/tests/testthat/_snaps/extract.md
@@ -1,3 +1,83 @@
+# error if no preprocessor
+
+    Code
+      extract_preprocessor(workflow())
+    Condition
+      Error in `extract_preprocessor()`:
+      ! The workflow does not have a preprocessor.
+
+# error if not a workflow
+
+    Code
+      extract_preprocessor(1)
+    Condition
+      Error in `UseMethod()`:
+      ! no applicable method for 'extract_preprocessor' applied to an object of class "c('double', 'numeric')"
+
+---
+
+    Code
+      extract_spec_parsnip(1)
+    Condition
+      Error in `UseMethod()`:
+      ! no applicable method for 'extract_spec_parsnip' applied to an object of class "c('double', 'numeric')"
+
+---
+
+    Code
+      extract_fit_parsnip(1)
+    Condition
+      Error in `UseMethod()`:
+      ! no applicable method for 'extract_fit_parsnip' applied to an object of class "c('double', 'numeric')"
+
+---
+
+    Code
+      extract_mold(1)
+    Condition
+      Error in `UseMethod()`:
+      ! no applicable method for 'extract_mold' applied to an object of class "c('double', 'numeric')"
+
+---
+
+    Code
+      extract_recipe(1)
+    Condition
+      Error in `UseMethod()`:
+      ! no applicable method for 'extract_recipe' applied to an object of class "c('double', 'numeric')"
+
+# error if no spec
+
+    Code
+      extract_spec_parsnip(workflow())
+    Condition
+      Error in `extract_spec_parsnip()`:
+      ! The workflow does not have a model spec.
+
+# error if no parsnip fit
+
+    Code
+      extract_fit_parsnip(workflow())
+    Condition
+      Error in `extract_fit_parsnip()`:
+      ! The workflow does not have a model fit. Have you called `fit()` yet?
+
+# error if no mold
+
+    Code
+      extract_mold(workflow())
+    Condition
+      Error in `extract_mold()`:
+      ! The workflow does not have a mold. Have you called `fit()` yet?
+
+---
+
+    Code
+      extract_recipe(workflow)
+    Condition
+      Error in `extract_mold()`:
+      ! The workflow does not have a mold. Have you called `fit()` yet?
+
 # can extract a prepped recipe
 
     Code
@@ -8,4 +88,20 @@
       x Problematic argument:
       * ..1 = FALSE
       i Did you forget to name an argument?
+
+---
+
+    Code
+      extract_recipe(workflow, estimated = "yes please")
+    Condition
+      Error in `extract_recipe()`:
+      ! `estimated` must be a single `TRUE` or `FALSE`.
+
+# error if no recipe preprocessor
+
+    Code
+      extract_recipe(workflow())
+    Condition
+      Error in `extract_recipe()`:
+      ! The workflow must have a recipe preprocessor.
 

--- a/tests/testthat/_snaps/fit-action-model.md
+++ b/tests/testthat/_snaps/fit-action-model.md
@@ -1,0 +1,16 @@
+# model is validated
+
+    Code
+      add_model(workflow(), 1)
+    Condition
+      Error in `new_action_model()`:
+      ! `spec` must be a `model_spec`.
+
+# cannot add two models
+
+    Code
+      add_model(workflow, mod)
+    Condition
+      Error in `add_action()`:
+      ! A `model` action has already been added to this workflow.
+

--- a/tests/testthat/_snaps/fit-action-model.md
+++ b/tests/testthat/_snaps/fit-action-model.md
@@ -11,6 +11,6 @@
     Code
       add_model(workflow, mod)
     Condition
-      Error in `add_action()`:
+      Error in `add_model()`:
       ! A `model` action has already been added to this workflow.
 

--- a/tests/testthat/_snaps/fit-action-model.md
+++ b/tests/testthat/_snaps/fit-action-model.md
@@ -3,7 +3,7 @@
     Code
       add_model(workflow(), 1)
     Condition
-      Error in `new_action_model()`:
+      Error in `add_model()`:
       ! `spec` must be a `model_spec`.
 
 # cannot add two models

--- a/tests/testthat/_snaps/fit.md
+++ b/tests/testthat/_snaps/fit.md
@@ -1,0 +1,40 @@
+# missing `data` argument has a nice error
+
+    Code
+      fit(workflow)
+    Condition
+      Error in `fit()`:
+      ! `data` must be provided to fit a workflow.
+
+# invalid `control` argument has a nice error
+
+    Code
+      fit(workflow, mtcars, control = control)
+    Condition
+      Error in `fit()`:
+      ! `control` must be a workflows control object created by `control_workflow()`.
+
+# cannot fit without a pre stage
+
+    Code
+      fit(workflow, mtcars)
+    Condition
+      Error in `.fit_pre()`:
+      ! The workflow must have formula, recipe, or variables preprocessor. Provide one with `add_formula()`, `add_recipe()`, or `add_variables()`.
+
+# cannot fit without a fit stage
+
+    Code
+      fit(workflow, mtcars)
+    Condition
+      Error in `validate_has_model()`:
+      ! The workflow must have a model. Provide one with `add_model()`.
+
+# can `predict()` from workflow fit from individual pieces
+
+    Code
+      predict(workflow_model, mtcars)
+    Condition
+      Error in `predict()`:
+      ! Workflow has not yet been trained. Do you need to call `fit()`?
+

--- a/tests/testthat/_snaps/fit.md
+++ b/tests/testthat/_snaps/fit.md
@@ -27,7 +27,7 @@
     Code
       fit(workflow, mtcars)
     Condition
-      Error in `validate_has_model()`:
+      Error in `.fit_pre()`:
       ! The workflow must have a model. Provide one with `add_model()`.
 
 # can `predict()` from workflow fit from individual pieces

--- a/tests/testthat/_snaps/pre-action-formula.md
+++ b/tests/testthat/_snaps/pre-action-formula.md
@@ -3,7 +3,7 @@
     Code
       add_formula(workflow(), 1)
     Condition
-      Error in `new_action_formula()`:
+      Error in `add_formula()`:
       ! `formula` must be a formula.
 
 # cannot add a formula if a recipe already exists
@@ -35,6 +35,6 @@
     Code
       add_formula(workflow, mpg ~ cyl, blueprint = blueprint)
     Condition
-      Error in `new_action_formula()`:
+      Error in `add_formula()`:
       ! `blueprint` must be a hardhat 'formula_blueprint'.
 

--- a/tests/testthat/_snaps/pre-action-formula.md
+++ b/tests/testthat/_snaps/pre-action-formula.md
@@ -27,7 +27,7 @@
     Code
       add_formula(workflow, mpg ~ cyl)
     Condition
-      Error in `add_action()`:
+      Error in `add_formula()`:
       ! A `formula` action has already been added to this workflow.
 
 # can only use a 'formula_blueprint' blueprint

--- a/tests/testthat/_snaps/pre-action-formula.md
+++ b/tests/testthat/_snaps/pre-action-formula.md
@@ -11,7 +11,7 @@
     Code
       add_formula(workflow, mpg ~ cyl)
     Condition
-      Error in `check_conflicts()`:
+      Error in `add_formula()`:
       ! A formula cannot be added when a recipe already exists.
 
 # cannot add a formula if variables already exist
@@ -19,7 +19,7 @@
     Code
       add_formula(workflow, mpg ~ cyl)
     Condition
-      Error in `check_conflicts()`:
+      Error in `add_formula()`:
       ! A formula cannot be added when variables already exist.
 
 # cannot add two formulas

--- a/tests/testthat/_snaps/pre-action-formula.md
+++ b/tests/testthat/_snaps/pre-action-formula.md
@@ -1,0 +1,40 @@
+# formula is validated
+
+    Code
+      add_formula(workflow(), 1)
+    Condition
+      Error in `new_action_formula()`:
+      ! `formula` must be a formula.
+
+# cannot add a formula if a recipe already exists
+
+    Code
+      add_formula(workflow, mpg ~ cyl)
+    Condition
+      Error in `check_conflicts()`:
+      ! A formula cannot be added when a recipe already exists.
+
+# cannot add a formula if variables already exist
+
+    Code
+      add_formula(workflow, mpg ~ cyl)
+    Condition
+      Error in `check_conflicts()`:
+      ! A formula cannot be added when variables already exist.
+
+# cannot add two formulas
+
+    Code
+      add_formula(workflow, mpg ~ cyl)
+    Condition
+      Error in `add_action()`:
+      ! A `formula` action has already been added to this workflow.
+
+# can only use a 'formula_blueprint' blueprint
+
+    Code
+      add_formula(workflow, mpg ~ cyl, blueprint = blueprint)
+    Condition
+      Error in `new_action_formula()`:
+      ! `blueprint` must be a hardhat 'formula_blueprint'.
+

--- a/tests/testthat/_snaps/pre-action-recipe.md
+++ b/tests/testthat/_snaps/pre-action-recipe.md
@@ -1,0 +1,40 @@
+# recipe is validated
+
+    Code
+      add_recipe(workflow(), 1)
+    Condition
+      Error in `new_action_recipe()`:
+      ! `recipe` must be a recipe.
+
+# cannot add a recipe if a formula already exists
+
+    Code
+      add_recipe(workflow, rec)
+    Condition
+      Error in `check_conflicts()`:
+      ! A recipe cannot be added when a formula already exists.
+
+# cannot add a recipe if variables already exist
+
+    Code
+      add_recipe(workflow, rec)
+    Condition
+      Error in `check_conflicts()`:
+      ! A recipe cannot be added when variables already exist.
+
+# cannot add two recipe
+
+    Code
+      add_recipe(workflow, rec)
+    Condition
+      Error in `add_action()`:
+      ! A `recipe` action has already been added to this workflow.
+
+# can only use a 'recipe_blueprint' blueprint
+
+    Code
+      add_recipe(workflow, rec, blueprint = blueprint)
+    Condition
+      Error in `new_action_recipe()`:
+      ! `blueprint` must be a hardhat 'recipe_blueprint'.
+

--- a/tests/testthat/_snaps/pre-action-recipe.md
+++ b/tests/testthat/_snaps/pre-action-recipe.md
@@ -27,7 +27,7 @@
     Code
       add_recipe(workflow, rec)
     Condition
-      Error in `add_action()`:
+      Error in `add_recipe()`:
       ! A `recipe` action has already been added to this workflow.
 
 # can only use a 'recipe_blueprint' blueprint

--- a/tests/testthat/_snaps/pre-action-recipe.md
+++ b/tests/testthat/_snaps/pre-action-recipe.md
@@ -3,7 +3,7 @@
     Code
       add_recipe(workflow(), 1)
     Condition
-      Error in `new_action_recipe()`:
+      Error in `add_recipe()`:
       ! `recipe` must be a recipe.
 
 # cannot add a recipe if a formula already exists
@@ -35,6 +35,6 @@
     Code
       add_recipe(workflow, rec, blueprint = blueprint)
     Condition
-      Error in `new_action_recipe()`:
+      Error in `add_recipe()`:
       ! `blueprint` must be a hardhat 'recipe_blueprint'.
 

--- a/tests/testthat/_snaps/pre-action-recipe.md
+++ b/tests/testthat/_snaps/pre-action-recipe.md
@@ -11,7 +11,7 @@
     Code
       add_recipe(workflow, rec)
     Condition
-      Error in `check_conflicts()`:
+      Error in `add_recipe()`:
       ! A recipe cannot be added when a formula already exists.
 
 # cannot add a recipe if variables already exist
@@ -19,7 +19,7 @@
     Code
       add_recipe(workflow, rec)
     Condition
-      Error in `check_conflicts()`:
+      Error in `add_recipe()`:
       ! A recipe cannot be added when variables already exist.
 
 # cannot add two recipe

--- a/tests/testthat/_snaps/pre-action-variables.md
+++ b/tests/testthat/_snaps/pre-action-variables.md
@@ -19,7 +19,7 @@
     Code
       add_variables(workflow, mpg, cyl)
     Condition
-      Error in `add_action()`:
+      Error in `add_variables()`:
       ! A `variables` action has already been added to this workflow.
 
 ---
@@ -27,7 +27,7 @@
     Code
       add_variables(workflow, variables = workflow_variables(mpg, cyl))
     Condition
-      Error in `add_action()`:
+      Error in `add_variables()`:
       ! A `variables` action has already been added to this workflow.
 
 # can only use a 'xy_blueprint' blueprint

--- a/tests/testthat/_snaps/pre-action-variables.md
+++ b/tests/testthat/_snaps/pre-action-variables.md
@@ -35,6 +35,6 @@
     Code
       add_variables(workflow, mpg, cyl, blueprint = blueprint)
     Condition
-      Error in `new_action_variables()`:
+      Error in `add_variables()`:
       ! `blueprint` must be a hardhat 'xy_blueprint'.
 

--- a/tests/testthat/_snaps/pre-action-variables.md
+++ b/tests/testthat/_snaps/pre-action-variables.md
@@ -1,0 +1,40 @@
+# cannot add variables if a recipe already exists
+
+    Code
+      add_variables(wf, y, x)
+    Condition
+      Error in `check_conflicts()`:
+      ! Variables cannot be added when a recipe already exists.
+
+# cannot add variables if a formula already exist
+
+    Code
+      add_variables(wf, y, x)
+    Condition
+      Error in `check_conflicts()`:
+      ! Variables cannot be added when a formula already exists.
+
+# cannot add two variables
+
+    Code
+      add_variables(workflow, mpg, cyl)
+    Condition
+      Error in `add_action()`:
+      ! A `variables` action has already been added to this workflow.
+
+---
+
+    Code
+      add_variables(workflow, variables = workflow_variables(mpg, cyl))
+    Condition
+      Error in `add_action()`:
+      ! A `variables` action has already been added to this workflow.
+
+# can only use a 'xy_blueprint' blueprint
+
+    Code
+      add_variables(workflow, mpg, cyl, blueprint = blueprint)
+    Condition
+      Error in `new_action_variables()`:
+      ! `blueprint` must be a hardhat 'xy_blueprint'.
+

--- a/tests/testthat/_snaps/pre-action-variables.md
+++ b/tests/testthat/_snaps/pre-action-variables.md
@@ -3,7 +3,7 @@
     Code
       add_variables(wf, y, x)
     Condition
-      Error in `check_conflicts()`:
+      Error in `add_variables()`:
       ! Variables cannot be added when a recipe already exists.
 
 # cannot add variables if a formula already exist
@@ -11,7 +11,7 @@
     Code
       add_variables(wf, y, x)
     Condition
-      Error in `check_conflicts()`:
+      Error in `add_variables()`:
       ! Variables cannot be added when a formula already exists.
 
 # cannot add two variables

--- a/tests/testthat/_snaps/predict.md
+++ b/tests/testthat/_snaps/predict.md
@@ -1,0 +1,8 @@
+# workflow must have been `fit()` before prediction can be done
+
+    Code
+      predict(workflow(), mtcars)
+    Condition
+      Error in `predict()`:
+      ! Workflow has not yet been trained. Do you need to call `fit()`?
+

--- a/tests/testthat/_snaps/pull.md
+++ b/tests/testthat/_snaps/pull.md
@@ -1,3 +1,51 @@
+# error if no preprocessor
+
+    Code
+      pull_workflow_preprocessor(workflow())
+    Condition
+      Error in `extract_preprocessor()`:
+      ! The workflow does not have a preprocessor.
+
+# error if not a workflow
+
+    Code
+      pull_workflow_preprocessor(1)
+    Condition
+      Error in `pull_workflow_preprocessor()`:
+      ! `x` must be a workflow, not a numeric.
+
+---
+
+    Code
+      pull_workflow_spec(1)
+    Condition
+      Error in `pull_workflow_spec()`:
+      ! `x` must be a workflow, not a numeric.
+
+---
+
+    Code
+      pull_workflow_fit(1)
+    Condition
+      Error in `pull_workflow_fit()`:
+      ! `x` must be a workflow, not a numeric.
+
+---
+
+    Code
+      pull_workflow_mold(1)
+    Condition
+      Error in `pull_workflow_mold()`:
+      ! `x` must be a workflow, not a numeric.
+
+---
+
+    Code
+      pull_workflow_prepped_recipe(1)
+    Condition
+      Error in `pull_workflow_prepped_recipe()`:
+      ! `x` must be a workflow, not a numeric.
+
 # `pull_workflow_preprocessor()` is soft-deprecated
 
     Code
@@ -6,6 +54,14 @@
       Warning:
       `pull_workflow_preprocessor()` was deprecated in workflows 0.2.3.
       Please use `extract_preprocessor()` instead.
+
+# error if no spec
+
+    Code
+      pull_workflow_spec(workflow())
+    Condition
+      Error in `extract_spec_parsnip()`:
+      ! The workflow does not have a model spec.
 
 # `pull_workflow_spec()` is soft-deprecated
 
@@ -16,6 +72,14 @@
       `pull_workflow_spec()` was deprecated in workflows 0.2.3.
       Please use `extract_spec_parsnip()` instead.
 
+# error if no fit
+
+    Code
+      pull_workflow_fit(workflow())
+    Condition
+      Error in `extract_fit_parsnip()`:
+      ! The workflow does not have a model fit. Have you called `fit()` yet?
+
 # `pull_workflow_fit()` is soft-deprecated
 
     Code
@@ -25,6 +89,22 @@
       `pull_workflow_fit()` was deprecated in workflows 0.2.3.
       Please use `extract_fit_parsnip()` instead.
 
+# error if no mold
+
+    Code
+      pull_workflow_mold(workflow())
+    Condition
+      Error in `extract_mold()`:
+      ! The workflow does not have a mold. Have you called `fit()` yet?
+
+---
+
+    Code
+      pull_workflow_prepped_recipe(workflow)
+    Condition
+      Error in `extract_mold()`:
+      ! The workflow does not have a mold. Have you called `fit()` yet?
+
 # `pull_workflow_mold()` is soft-deprecated
 
     Code
@@ -33,6 +113,14 @@
       Warning:
       `pull_workflow_mold()` was deprecated in workflows 0.2.3.
       Please use `extract_mold()` instead.
+
+# error if no recipe preprocessor
+
+    Code
+      pull_workflow_prepped_recipe(workflow())
+    Condition
+      Error in `extract_recipe()`:
+      ! The workflow must have a recipe preprocessor.
 
 # `pull_workflow_prepped_recipe()` is soft-deprecated
 

--- a/tests/testthat/_snaps/workflow.md
+++ b/tests/testthat/_snaps/workflow.md
@@ -1,3 +1,27 @@
+# workflow must be the first argument when adding actions
+
+    Code
+      add_formula(1, mpg ~ cyl)
+    Condition
+      Error in `add_formula()`:
+      ! `x` must be a workflow, not a numeric.
+
+---
+
+    Code
+      add_recipe(1, rec)
+    Condition
+      Error in `add_recipe()`:
+      ! `x` must be a workflow, not a numeric.
+
+---
+
+    Code
+      add_model(1, mod)
+    Condition
+      Error in `add_model()`:
+      ! `x` must be a workflow, not a numeric.
+
 # model spec is validated
 
     Code
@@ -13,6 +37,38 @@
     Condition
       Error in `add_preprocessor()`:
       ! `preprocessor` must be a formula, recipe, or a set of workflow variables.
+
+# constructor validates input
+
+    Code
+      new_workflow(pre = 1)
+    Condition
+      Error in `new_workflow()`:
+      ! `pre` must be a `stage`.
+
+---
+
+    Code
+      new_workflow(fit = 1)
+    Condition
+      Error in `new_workflow()`:
+      ! `fit` must be a `stage`.
+
+---
+
+    Code
+      new_workflow(post = 1)
+    Condition
+      Error in `new_workflow()`:
+      ! `post` must be a `stage`.
+
+---
+
+    Code
+      new_workflow(trained = 1)
+    Condition
+      Error in `new_workflow()`:
+      ! `trained` must be a single logical value.
 
 # input must be a workflow
 

--- a/tests/testthat/_snaps/workflow.md
+++ b/tests/testthat/_snaps/workflow.md
@@ -35,7 +35,7 @@
     Code
       workflow(preprocessor = 1)
     Condition
-      Error in `add_preprocessor()`:
+      Error in `workflow()`:
       ! `preprocessor` must be a formula, recipe, or a set of workflow variables.
 
 # constructor validates input

--- a/tests/testthat/_snaps/workflow.md
+++ b/tests/testthat/_snaps/workflow.md
@@ -27,7 +27,7 @@
     Code
       workflow(spec = 1)
     Condition
-      Error in `new_action_model()`:
+      Error in `add_model()`:
       ! `spec` must be a `model_spec`.
 
 # preprocessor is validated

--- a/tests/testthat/test-broom.R
+++ b/tests/testthat/test-broom.R
@@ -3,19 +3,19 @@
 
 test_that("can't tidy the model of an unfit workflow", {
   x <- workflow()
-  expect_error(tidy(x), "does not have a model fit")
+  expect_snapshot(error = TRUE, tidy(x))
 })
 
 test_that("can't tidy the recipe of an unfit workflow", {
   x <- workflow()
 
-  expect_error(tidy(x, what = "recipe"), "must have a recipe preprocessor")
+  expect_snapshot(error = TRUE, tidy(x, what = "recipe"))
 
   rec <- recipes::recipe(y ~ x, data.frame(y = 1, x = 1))
 
   x <- add_recipe(x, rec)
 
-  expect_error(tidy(x, what = "recipe"), "does not have a mold")
+  expect_snapshot(error = TRUE, tidy(x, what = "recipe"))
 })
 
 test_that("can tidy workflow model or recipe", {
@@ -137,5 +137,6 @@ test_that("augment fails if it can't preprocess `new_data`", {
 
   wf <- fit(wf, df)
 
-  expect_error(augment(wf, new_data), class = "vctrs_error_incompatible_type")
+  # vctrs type error
+  expect_error(augment(wf, new_data))
 })

--- a/tests/testthat/test-butcher.R
+++ b/tests/testthat/test-butcher.R
@@ -16,7 +16,7 @@ test_that("attaches the butcher class", {
 
 test_that("fails if not a fitted workflow", {
   skip_if_not_installed("butcher")
-  expect_error(butcher::butcher(workflow()))
+  expect_snapshot(error = TRUE, butcher::butcher(workflow()))
 })
 
 test_that("can axe the call", {

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -7,8 +7,7 @@ test_that("default parsnip control is created", {
 })
 
 test_that("parsnip control is validated", {
-  expect_error(
-    control_workflow(control_parsnip = 1),
-    "must be a 'control_parsnip' object"
-  )
+  expect_snapshot(error = TRUE, {
+    control_workflow(control_parsnip = 1)
+  })
 })

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -38,17 +38,11 @@ test_that("can extract a variables preprocessor", {
 })
 
 test_that("error if no preprocessor", {
-  expect_error(
-    extract_preprocessor(workflow()),
-    "does not have a preprocessor"
-  )
+  expect_snapshot(error = TRUE, extract_preprocessor(workflow()))
 })
 
 test_that("error if not a workflow", {
-  expect_error(
-    extract_preprocessor(1),
-    "no applicable method"
-  )
+  expect_snapshot(error = TRUE, extract_preprocessor(1))
 })
 
 # ------------------------------------------------------------------------------
@@ -67,17 +61,11 @@ test_that("can extract a model spec", {
 })
 
 test_that("error if no spec", {
-  expect_error(
-    extract_spec_parsnip(workflow()),
-    "does not have a model spec"
-  )
+  expect_snapshot(error = TRUE, extract_spec_parsnip(workflow()))
 })
 
 test_that("error if not a workflow", {
-  expect_error(
-    extract_spec_parsnip(1),
-    "no applicable method for"
-  )
+  expect_snapshot(error = TRUE, extract_spec_parsnip(1))
 })
 
 # ------------------------------------------------------------------------------
@@ -100,17 +88,11 @@ test_that("can extract a parsnip model fit", {
 })
 
 test_that("error if no parsnip fit", {
-  expect_error(
-    extract_fit_parsnip(workflow()),
-    "does not have a model fit. Have you called `fit[(][)]` yet?"
-  )
+  expect_snapshot(error = TRUE, extract_fit_parsnip(workflow()))
 })
 
 test_that("error if not a workflow", {
-  expect_error(
-    extract_fit_parsnip(1),
-    "no applicable method for"
-  )
+  expect_snapshot(error = TRUE, extract_fit_parsnip(1))
 })
 
 # ------------------------------------------------------------------------------
@@ -154,17 +136,11 @@ test_that("can extract a mold", {
 })
 
 test_that("error if no mold", {
-  expect_error(
-    extract_mold(workflow()),
-    "does not have a mold. Have you called `fit[(][)]` yet?"
-  )
+  expect_snapshot(error = TRUE, extract_mold(workflow()))
 })
 
 test_that("error if not a workflow", {
-  expect_error(
-    extract_mold(1),
-    "no applicable method"
-  )
+  expect_snapshot(error = TRUE, extract_mold(1))
 })
 
 # ------------------------------------------------------------------------------
@@ -190,18 +166,11 @@ test_that("can extract a prepped recipe", {
   )
 
   expect_snapshot(error = TRUE, extract_recipe(workflow, FALSE))
-
-  expect_error(
-    extract_recipe(workflow, estimated = "yes please"),
-    "`estimated` must be a single `TRUE` or `FALSE`"
-  )
+  expect_snapshot(error = TRUE, extract_recipe(workflow, estimated = "yes please"))
 })
 
 test_that("error if no recipe preprocessor", {
-  expect_error(
-    extract_recipe(workflow()),
-    "must have a recipe preprocessor"
-  )
+  expect_snapshot(error = TRUE, extract_recipe(workflow()))
 })
 
 test_that("error if no mold", {
@@ -210,17 +179,11 @@ test_that("error if no mold", {
   workflow <- workflow()
   workflow <- add_recipe(workflow, recipe)
 
-  expect_error(
-    extract_recipe(workflow),
-    "does not have a mold. Have you called `fit[(][)]` yet?"
-  )
+  expect_snapshot(error = TRUE, extract_recipe(workflow))
 })
 
 test_that("error if not a workflow", {
-  expect_error(
-    extract_recipe(1),
-    "no applicable method for"
-  )
+  expect_snapshot(error = TRUE, extract_recipe(1))
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-fit-action-model.R
+++ b/tests/testthat/test-fit-action-model.R
@@ -9,7 +9,7 @@ test_that("can add a model to a workflow", {
 })
 
 test_that("model is validated", {
-  expect_error(add_model(workflow(), 1), "`spec` must be a `model_spec`")
+  expect_snapshot(error = TRUE, add_model(workflow(), 1))
 })
 
 test_that("cannot add two models", {
@@ -19,7 +19,7 @@ test_that("cannot add two models", {
   workflow <- workflow()
   workflow <- add_model(workflow, mod)
 
-  expect_error(add_model(workflow, mod), "`model` action has already been added")
+  expect_snapshot(error = TRUE, add_model(workflow, mod))
 })
 
 test_that("can provide a model formula override", {

--- a/tests/testthat/test-fit.R
+++ b/tests/testthat/test-fit.R
@@ -46,7 +46,7 @@ test_that("missing `data` argument has a nice error", {
   workflow <- add_formula(workflow, mpg ~ cyl)
   workflow <- add_model(workflow, mod)
 
-  expect_error(fit(workflow), "`data` must be provided to fit a workflow")
+  expect_snapshot(error = TRUE, fit(workflow))
 })
 
 test_that("invalid `control` argument has a nice error", {
@@ -59,10 +59,9 @@ test_that("invalid `control` argument has a nice error", {
 
   control <- parsnip::control_parsnip()
 
-  expect_error(
-    fit(workflow, mtcars, control = control),
-    "`control` must be a workflows control object created by `control_workflow[(][)]`."
-  )
+  expect_snapshot(error = TRUE, {
+    fit(workflow, mtcars, control = control)
+  })
 })
 
 test_that("cannot fit without a pre stage", {
@@ -72,14 +71,18 @@ test_that("cannot fit without a pre stage", {
   workflow <- workflow()
   workflow <- add_model(workflow, mod)
 
-  expect_error(fit(workflow, mtcars), "formula, recipe, or variables")
+  expect_snapshot(error = TRUE, {
+    fit(workflow, mtcars)
+  })
 })
 
 test_that("cannot fit without a fit stage", {
   workflow <- workflow()
   workflow <- add_formula(workflow, mpg ~ cyl)
 
-  expect_error(fit(workflow, mtcars), "must have a model")
+  expect_snapshot(error = TRUE, {
+    fit(workflow, mtcars)
+  })
 })
 
 # ------------------------------------------------------------------------------
@@ -203,6 +206,6 @@ test_that("can `predict()` from workflow fit from individual pieces", {
   workflow_fit <- fit(workflow, mtcars)
   expect <- predict(workflow_fit, mtcars)
 
-  expect_error(predict(workflow_model, mtcars), "has not yet been trained")
+  expect_snapshot(error = TRUE, predict(workflow_model, mtcars))
   expect_identical(predict(workflow_final, mtcars), expect)
 })

--- a/tests/testthat/test-pre-action-formula.R
+++ b/tests/testthat/test-pre-action-formula.R
@@ -6,7 +6,7 @@ test_that("can add a formula to a workflow", {
 })
 
 test_that("formula is validated", {
-  expect_error(add_formula(workflow(), 1), "`formula` must be a formula")
+  expect_snapshot(error = TRUE, add_formula(workflow(), 1))
 })
 
 test_that("cannot add a formula if a recipe already exists", {
@@ -15,14 +15,14 @@ test_that("cannot add a formula if a recipe already exists", {
   workflow <- workflow()
   workflow <- add_recipe(workflow, rec)
 
-  expect_error(add_formula(workflow, mpg ~ cyl), "cannot be added when a recipe already exists")
+  expect_snapshot(error = TRUE, add_formula(workflow, mpg ~ cyl))
 })
 
 test_that("cannot add a formula if variables already exist", {
   workflow <- workflow()
   workflow <- add_variables(workflow, y, x)
 
-  expect_error(add_formula(workflow, mpg ~ cyl), "cannot be added when variables already exist")
+  expect_snapshot(error = TRUE, add_formula(workflow, mpg ~ cyl))
 })
 
 test_that("formula preprocessing is executed upon `fit()`", {
@@ -50,7 +50,7 @@ test_that("cannot add two formulas", {
   workflow <- workflow()
   workflow <- add_formula(workflow, mpg ~ cyl)
 
-  expect_error(add_formula(workflow, mpg ~ cyl), "`formula` action has already been added")
+  expect_snapshot(error = TRUE, add_formula(workflow, mpg ~ cyl))
 })
 
 test_that("remove a formula", {
@@ -125,8 +125,5 @@ test_that("can only use a 'formula_blueprint' blueprint", {
 
   workflow <- workflow()
 
-  expect_error(
-    add_formula(workflow, mpg ~ cyl, blueprint = blueprint),
-    "must be a hardhat 'formula_blueprint'"
-  )
+  expect_snapshot(error = TRUE, add_formula(workflow, mpg ~ cyl, blueprint = blueprint))
 })

--- a/tests/testthat/test-pre-action-recipe.R
+++ b/tests/testthat/test-pre-action-recipe.R
@@ -8,7 +8,7 @@ test_that("can add a recipe to a workflow", {
 })
 
 test_that("recipe is validated", {
-  expect_error(add_recipe(workflow(), 1), "`recipe` must be a recipe")
+  expect_snapshot(error = TRUE, add_recipe(workflow(), 1))
 })
 
 test_that("cannot add a recipe if a formula already exists", {
@@ -17,7 +17,7 @@ test_that("cannot add a recipe if a formula already exists", {
   workflow <- workflow()
   workflow <- add_formula(workflow, mpg ~ cyl)
 
-  expect_error(add_recipe(workflow, rec), "cannot be added when a formula already exists")
+  expect_snapshot(error = TRUE, add_recipe(workflow, rec))
 })
 
 test_that("cannot add a recipe if variables already exist", {
@@ -26,7 +26,7 @@ test_that("cannot add a recipe if variables already exist", {
   workflow <- workflow()
   workflow <- add_variables(workflow, y, x)
 
-  expect_error(add_recipe(workflow, rec), "cannot be added when variables already exist")
+  expect_snapshot(error = TRUE, add_recipe(workflow, rec))
 })
 
 test_that("remove a recipe", {
@@ -123,7 +123,7 @@ test_that("cannot add two recipe", {
   workflow <- workflow()
   workflow <- add_recipe(workflow, rec)
 
-  expect_error(add_recipe(workflow, rec), "`recipe` action has already been added")
+  expect_snapshot(error = TRUE, add_recipe(workflow, rec))
 })
 
 test_that("can pass a blueprint through to hardhat::mold()", {
@@ -151,8 +151,5 @@ test_that("can only use a 'recipe_blueprint' blueprint", {
 
   workflow <- workflow()
 
-  expect_error(
-    add_recipe(workflow, rec, blueprint = blueprint),
-    "must be a hardhat 'recipe_blueprint'"
-  )
+  expect_snapshot(error = TRUE, add_recipe(workflow, rec, blueprint = blueprint))
 })

--- a/tests/testthat/test-pre-action-variables.R
+++ b/tests/testthat/test-pre-action-variables.R
@@ -24,14 +24,14 @@ test_that("cannot add variables if a recipe already exists", {
   wf <- workflow()
   wf <- add_recipe(wf, rec)
 
-  expect_error(add_variables(wf, y, x), "cannot be added when a recipe already exists")
+  expect_snapshot(error = TRUE, add_variables(wf, y, x))
 })
 
 test_that("cannot add variables if a formula already exist", {
   wf <- workflow()
   wf <- add_formula(wf, mpg ~ cyl)
 
-  expect_error(add_variables(wf, y, x), "cannot be added when a formula already exists")
+  expect_snapshot(error = TRUE, add_variables(wf, y, x))
 })
 
 test_that("works with fit()", {
@@ -163,7 +163,8 @@ test_that("`outcomes` are removed from set of possible `predictors` (#72)", {
 
   workflow2 <- add_variables(workflow, mpg, mpg)
 
-  expect_error(.fit_pre(workflow2, mtcars), class = "vctrs_error_subscript_oob")
+  # vctrs subscript error
+  expect_error(.fit_pre(workflow2, mtcars))
 })
 
 test_that("selecting no `outcomes` doesn't break selection of `predictors`", {
@@ -196,8 +197,8 @@ test_that("cannot add two variables", {
   workflow <- workflow()
   workflow <- add_variables(workflow, mpg, cyl)
 
-  expect_error(add_variables(workflow, mpg, cyl), "`variables` action has already been added")
-  expect_error(add_variables(workflow, variables = workflow_variables(mpg, cyl)), "`variables` action has already been added")
+  expect_snapshot(error = TRUE, add_variables(workflow, mpg, cyl))
+  expect_snapshot(error = TRUE, add_variables(workflow, variables = workflow_variables(mpg, cyl)))
 })
 
 test_that("can remove variables", {
@@ -245,10 +246,7 @@ test_that("can only use a 'xy_blueprint' blueprint", {
 
   workflow <- workflow()
 
-  expect_error(
-    add_variables(workflow, mpg, cyl, blueprint = blueprint),
-    "must be a hardhat 'xy_blueprint'"
-  )
+  expect_snapshot(error = TRUE, add_variables(workflow, mpg, cyl, blueprint = blueprint))
 })
 
 test_that("can pass a blueprint through to hardhat::mold()", {

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -15,7 +15,7 @@ test_that("can predict from a workflow", {
 })
 
 test_that("workflow must have been `fit()` before prediction can be done", {
-  expect_error(predict(workflow(), mtcars), "Workflow has not yet been trained")
+  expect_snapshot(error = TRUE, predict(workflow(), mtcars))
 })
 
 test_that("formula preprocessing is done to the `new_data`", {
@@ -91,7 +91,8 @@ test_that("`new_data` must have all of the original predictors", {
   cars_no_cyl <- mtcars
   cars_no_cyl$cyl <- NULL
 
-  expect_error(predict(fit_workflow, cars_no_cyl), "missing: 'cyl'")
+  # This error comes from hardhat, so we don't snapshot it
+  expect_error(predict(fit_workflow, cars_no_cyl))
 })
 
 test_that("blueprint will get passed on to hardhat::forge()", {
@@ -146,6 +147,7 @@ test_that("monitoring: known that parsnip removes blueprint intercept for some m
   fit_with_intercept <- fit(workflow_with_intercept, mtcars)
 
   # `parsnip:::prepare_data()` will remove the intercept, so it won't be
-  # there when the `lm()` `predict()` method is called.
+  # there when the `lm()` `predict()` method is called. We don't own this
+  # error though.
   expect_error(predict(fit_with_intercept, mtcars))
 })

--- a/tests/testthat/test-pull.R
+++ b/tests/testthat/test-pull.R
@@ -44,19 +44,13 @@ test_that("can pull a variables preprocessor", {
 test_that("error if no preprocessor", {
   local_lifecycle_quiet()
 
-  expect_error(
-    pull_workflow_preprocessor(workflow()),
-    "does not have a preprocessor"
-  )
+  expect_snapshot(error = TRUE, pull_workflow_preprocessor(workflow()))
 })
 
 test_that("error if not a workflow", {
   local_lifecycle_quiet()
 
-  expect_error(
-    pull_workflow_preprocessor(1),
-    "must be a workflow"
-  )
+  expect_snapshot(error = TRUE, pull_workflow_preprocessor(1))
 })
 
 test_that("`pull_workflow_preprocessor()` is soft-deprecated", {
@@ -86,19 +80,13 @@ test_that("can pull a model spec", {
 test_that("error if no spec", {
   local_lifecycle_quiet()
 
-  expect_error(
-    pull_workflow_spec(workflow()),
-    "does not have a model spec"
-  )
+  expect_snapshot(error = TRUE, pull_workflow_spec(workflow()))
 })
 
 test_that("error if not a workflow", {
   local_lifecycle_quiet()
 
-  expect_error(
-    pull_workflow_spec(1),
-    "must be a workflow"
-  )
+  expect_snapshot(error = TRUE, pull_workflow_spec(1))
 })
 
 test_that("`pull_workflow_spec()` is soft-deprecated", {
@@ -134,19 +122,13 @@ test_that("can pull a model fit", {
 test_that("error if no fit", {
   local_lifecycle_quiet()
 
-  expect_error(
-    pull_workflow_fit(workflow()),
-    "does not have a model fit. Have you called `fit[(][)]` yet?"
-  )
+  expect_snapshot(error = TRUE, pull_workflow_fit(workflow()))
 })
 
 test_that("error if not a workflow", {
   local_lifecycle_quiet()
 
-  expect_error(
-    pull_workflow_fit(1),
-    "must be a workflow"
-  )
+  expect_snapshot(error = TRUE, pull_workflow_fit(1))
 })
 
 test_that("`pull_workflow_fit()` is soft-deprecated", {
@@ -188,19 +170,13 @@ test_that("can pull a mold", {
 test_that("error if no mold", {
   local_lifecycle_quiet()
 
-  expect_error(
-    pull_workflow_mold(workflow()),
-    "does not have a mold. Have you called `fit[(][)]` yet?"
-  )
+  expect_snapshot(error = TRUE, pull_workflow_mold(workflow()))
 })
 
 test_that("error if not a workflow", {
   local_lifecycle_quiet()
 
-  expect_error(
-    pull_workflow_mold(1),
-    "must be a workflow"
-  )
+  expect_snapshot(error = TRUE, pull_workflow_mold(1))
 })
 
 test_that("`pull_workflow_mold()` is soft-deprecated", {
@@ -244,10 +220,7 @@ test_that("can pull a prepped recipe", {
 test_that("error if no recipe preprocessor", {
   local_lifecycle_quiet()
 
-  expect_error(
-    pull_workflow_prepped_recipe(workflow()),
-    "must have a recipe preprocessor"
-  )
+  expect_snapshot(error = TRUE, pull_workflow_prepped_recipe(workflow()))
 })
 
 test_that("error if no mold", {
@@ -258,19 +231,13 @@ test_that("error if no mold", {
   workflow <- workflow()
   workflow <- add_recipe(workflow, recipe)
 
-  expect_error(
-    pull_workflow_prepped_recipe(workflow),
-    "does not have a mold. Have you called `fit[(][)]` yet?"
-  )
+  expect_snapshot(error = TRUE, pull_workflow_prepped_recipe(workflow))
 })
 
 test_that("error if not a workflow", {
   local_lifecycle_quiet()
 
-  expect_error(
-    pull_workflow_prepped_recipe(1),
-    "must be a workflow"
-  )
+  expect_snapshot(error = TRUE, pull_workflow_prepped_recipe(1))
 })
 
 test_that("`pull_workflow_prepped_recipe()` is soft-deprecated", {

--- a/tests/testthat/test-workflow.R
+++ b/tests/testthat/test-workflow.R
@@ -23,9 +23,9 @@ test_that("workflow must be the first argument when adding actions", {
   rec <- recipes::recipe(mpg ~ cyl, mtcars)
   mod <- parsnip::linear_reg()
 
-  expect_error(add_formula(1, mpg ~ cyl), "must be a workflow")
-  expect_error(add_recipe(1, rec), "must be a workflow")
-  expect_error(add_model(1, mod), "must be a workflow")
+  expect_snapshot(error = TRUE, add_formula(1, mpg ~ cyl))
+  expect_snapshot(error = TRUE, add_recipe(1, rec))
+  expect_snapshot(error = TRUE, add_model(1, mod))
 })
 
 test_that("can add a model spec directly to a workflow", {
@@ -61,11 +61,11 @@ test_that("preprocessor is validated", {
 # new_workflow()
 
 test_that("constructor validates input", {
-  expect_error(new_workflow(pre = 1), "must be a `stage`")
-  expect_error(new_workflow(fit = 1), "must be a `stage`")
-  expect_error(new_workflow(post = 1), "must be a `stage`")
+  expect_snapshot(error = TRUE, new_workflow(pre = 1))
+  expect_snapshot(error = TRUE, new_workflow(fit = 1))
+  expect_snapshot(error = TRUE, new_workflow(post = 1))
 
-  expect_error(new_workflow(trained = 1), "must be a single logical value")
+  expect_snapshot(error = TRUE, new_workflow(trained = 1))
 })
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
- Updated most `expect_error()` calls to `expect_snapshot(error = TRUE)`. That way we can track the changes as we pass through the error call.
- Marked many errors as `abort(.internal = TRUE)`
- Passed the error call through the rest of the calls to `abort()` where applicable

Whenever I added `call = caller_env()` to a function signature, I also added `...` and used `check_dots_empty()`. This is a bit overkill, but it forces me to name this argument as I pass it through, and ensures there won't be any accidental typos. I don't trust myself 😬 