### PR TITLE
use main pkg refs in `Remotes`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,8 +37,8 @@ Suggests:
     testthat (>= 3.0.0)
 Remotes:
     tidymodels/hardhat,
-    tidymodels/parsnip@feature/case-weights,
-    tidymodels/recipes@case-weights
+    tidymodels/parsnip,
+    tidymodels/recipes
 VignetteBuilder: 
     knitr
 Config/Needs/website:


### PR DESCRIPTION
Now that case weights branches have been merged, we can use the `main` refs in `Remotes` across all repos. :) Currently seeing:

```
pkgs <- c("hardhat", "parsnip", "recipes",
          "modeldata", "tune", "workflows", "yardstick")
pkgs <- paste0("tidymodels/", pkgs)
pak::pak(pkgs)
#> Error: Cannot install packages:                                                  
#> * tidymodels/tune: Can't install dependency tidymodels/parsnip@feature/case-weights
#> * tidymodels/parsnip@feature/case-weights: Conflicts with tidymodels/parsnip
```