### PR TITLE
Run `axe_fitted()` on recipe preprocessors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # workflows (development version)
 
+* `butcher::axe_fitted()` now axes the recipe preprocessor that is stored inside
+  a workflow, which will reduce the size of the `template` data frame that is
+  stored in the recipe (#147).
+
 * `add_model()` now errors informatively if you try to add a model specification
   that contains an unknown mode (#160).
 

--- a/R/butcher.R
+++ b/R/butcher.R
@@ -80,6 +80,15 @@ axe_fitted.workflow <- function(x, verbose = FALSE, ...) {
   fit <- extract_fit_parsnip(x)
   fit <- butcher::axe_fitted(fit, verbose = verbose, ...)
   x <- replace_workflow_fit(x, fit)
+
+  if (has_preprocessor_recipe(x)) {
+    # hardhat already removes the `$template` from the fitted recipe that we get
+    # back from `extract_recipe()`, so we only axe the preprocessor recipe here.
+    preprocessor <- extract_preprocessor(x)
+    preprocessor <- butcher::axe_fitted(preprocessor, verbose = verbose, ...)
+    x <- replace_workflow_preprocessor(x, preprocessor)
+  }
+
   add_butcher_class(x)
 }
 

--- a/tests/testthat/test-butcher.R
+++ b/tests/testthat/test-butcher.R
@@ -51,6 +51,33 @@ test_that("can axe the fitted bits", {
   expect_identical(fit$fit$fit$fit$fitted.values, numeric())
 })
 
+test_that("can axe the `$template` in a recipe preprocessor through `axe_fitted()` (#147)", {
+  skip_if_not_installed("butcher")
+
+  model <- parsnip::linear_reg()
+  model <- parsnip::set_engine(model, "lm")
+
+  rec <- recipes::recipe(mpg ~ cyl + disp, mtcars)
+  rec <- recipes::step_center(rec, cyl, disp)
+
+  wf <- workflow()
+  wf <- add_model(wf, model)
+  wf <- add_recipe(wf, rec)
+
+  fit <- fit(wf, mtcars)
+  fit <- butcher::axe_fitted(fit)
+
+  # `axe_fitted()` is run on the un-fitted recipe to remove the `$template`
+  expect_identical(
+    fit$pre$actions$recipe$recipe$template,
+    vctrs::vec_ptype(rec$template)
+  )
+
+  # `hardhat:::compost()` removed the template from the fitted recipe when
+  # `hardhat::mold()` was run
+  expect_null(fit$pre$mold$blueprint$recipe$template)
+})
+
 test_that("axing the data removes the outcomes/predictors", {
   skip_if_not_installed("butcher")
 


### PR DESCRIPTION
Closes #147 