### PR TITLE
prompt on `add_model()` when missing implementation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     glue (>= 1.6.2),
     hardhat (>= 1.2.0),
     lifecycle (>= 1.0.1),
-    parsnip (>= 1.0.0),
+    parsnip (>= 1.0.1.9000),
     rlang (>= 1.0.3),
     tidyselect (>= 1.1.2),
     vctrs (>= 0.4.1)
@@ -45,6 +45,8 @@ Config/Needs/website:
     tidyr,
     tidyverse/tidytemplate,
     yardstick
+Remotes:
+    tidymodels/parsnip
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/fit-action-model.R
+++ b/R/fit-action-model.R
@@ -190,21 +190,8 @@ new_action_model <- function(spec, formula, ..., call = caller_env()) {
     abort("`formula` must be a formula, or `NULL`.", call = call)
   }
 
-  if (!parsnip::spec_is_loaded(
-    cls = class(spec)[1],
-    engine = spec$engine,
-    user_specified_engine = spec$user_specified_engine,
-    mode = spec$mode,
-    user_specified_mode = spec$user_specified_mode
-  )) {
-    parsnip::prompt_missing_implementation(
-      cls = class(spec)[1],
-      engine = spec$engine,
-      user_specified_engine = spec$user_specified_engine,
-      mode = spec$mode,
-      user_specified_mode = spec$user_specified_mode,
-      prompt = cli::cli_inform
-    )
+  if (!parsnip::spec_is_loaded(spec = spec)) {
+    parsnip::prompt_missing_implementation(spec = spec, prompt = cli::cli_inform)
   }
 
   new_action_fit(spec = spec, formula = formula, subclass = "action_model")

--- a/R/fit-action-model.R
+++ b/R/fit-action-model.R
@@ -190,5 +190,22 @@ new_action_model <- function(spec, formula, ..., call = caller_env()) {
     abort("`formula` must be a formula, or `NULL`.", call = call)
   }
 
+  if (!parsnip::spec_is_loaded(
+    cls = class(spec)[1],
+    engine = spec$engine,
+    user_specified_engine = spec$user_specified_engine,
+    mode = spec$mode,
+    user_specified_mode = spec$user_specified_mode
+  )) {
+    parsnip::prompt_missing_implementation(
+      cls = class(spec)[1],
+      engine = spec$engine,
+      user_specified_engine = spec$user_specified_engine,
+      mode = spec$mode,
+      user_specified_mode = spec$user_specified_mode,
+      prompt = cli::cli_inform
+    )
+  }
+
   new_action_fit(spec = spec, formula = formula, subclass = "action_model")
 }

--- a/R/fit-action-model.R
+++ b/R/fit-action-model.R
@@ -191,7 +191,11 @@ new_action_model <- function(spec, formula, ..., call = caller_env()) {
   }
 
   if (!parsnip::spec_is_loaded(spec = spec)) {
-    parsnip::prompt_missing_implementation(spec = spec, prompt = cli::cli_inform)
+    parsnip::prompt_missing_implementation(
+      spec = spec,
+      prompt = cli::cli_abort,
+      call = call
+    )
   }
 
   new_action_fit(spec = spec, formula = formula, subclass = "action_model")

--- a/tests/testthat/_snaps/fit-action-model.md
+++ b/tests/testthat/_snaps/fit-action-model.md
@@ -15,6 +15,34 @@
       ! `spec` must have a known mode.
       i Set the mode of `spec` by using `parsnip::set_mode()` or by setting the mode directly in the parsnip specification function.
 
+# prompt on spec without a loaded implementation (#174)
+
+    Code
+      add_model(workflow, mod)
+    Message
+      ! parsnip could not locate an implementation for `bag_tree` regression model specifications using the `rpart` engine.
+      i The parsnip extension package baguette implements support for this specification.
+      i Please install (if needed) and load to continue.
+    Output
+      == Workflow ====================================================================
+      Preprocessor: None
+      Model: bag_tree()
+      
+      -- Model -----------------------------------------------------------------------
+    Message
+      ! parsnip could not locate an implementation for `bag_tree` regression model specifications using the `rpart` engine.
+      i The parsnip extension package baguette implements support for this specification.
+      i Please install (if needed) and load to continue.
+    Output
+      Bagged Decision Tree Model Specification (regression)
+      
+      Main Arguments:
+        cost_complexity = 0
+        min_n = 2
+      
+      Computational engine: rpart 
+      
+
 # cannot add two models
 
     Code

--- a/tests/testthat/_snaps/fit-action-model.md
+++ b/tests/testthat/_snaps/fit-action-model.md
@@ -19,29 +19,21 @@
 
     Code
       add_model(workflow, mod)
-    Message
-      ! parsnip could not locate an implementation for `bag_tree` regression model specifications using the `rpart` engine.
+    Condition
+      Error in `add_model()`:
+      ! parsnip could not locate an implementation for `bag_tree` regression model specifications.
       i The parsnip extension package baguette implements support for this specification.
       i Please install (if needed) and load to continue.
-    Output
-      == Workflow ====================================================================
-      Preprocessor: None
-      Model: bag_tree()
-      
-      -- Model -----------------------------------------------------------------------
-    Message
-      ! parsnip could not locate an implementation for `bag_tree` regression model specifications using the `rpart` engine.
+
+---
+
+    Code
+      workflow(spec = mod)
+    Condition
+      Error in `add_model()`:
+      ! parsnip could not locate an implementation for `bag_tree` regression model specifications.
       i The parsnip extension package baguette implements support for this specification.
       i Please install (if needed) and load to continue.
-    Output
-      Bagged Decision Tree Model Specification (regression)
-      
-      Main Arguments:
-        cost_complexity = 0
-        min_n = 2
-      
-      Computational engine: rpart 
-      
 
 # cannot add two models
 

--- a/tests/testthat/test-fit-action-model.R
+++ b/tests/testthat/test-fit-action-model.R
@@ -24,14 +24,12 @@ test_that("model must contain a known mode (#160)", {
 
 test_that("prompt on spec without a loaded implementation (#174)", {
   mod <- parsnip::bag_tree() %>%
-    parsnip::set_engine("rpart") %>%
     parsnip::set_mode("regression")
 
   workflow <- workflow()
 
-  expect_snapshot({
-    add_model(workflow, mod)
-  })
+  expect_snapshot(error = TRUE, add_model(workflow, mod))
+  expect_snapshot(error = TRUE, workflow(spec = mod))
 })
 
 test_that("cannot add two models", {

--- a/tests/testthat/test-fit-action-model.R
+++ b/tests/testthat/test-fit-action-model.R
@@ -22,6 +22,18 @@ test_that("model must contain a known mode (#160)", {
   })
 })
 
+test_that("prompt on spec without a loaded implementation (#174)", {
+  mod <- parsnip::bag_tree() %>%
+    parsnip::set_engine("rpart") %>%
+    parsnip::set_mode("regression")
+
+  workflow <- workflow()
+
+  expect_snapshot({
+    add_model(workflow, mod)
+  })
+})
+
 test_that("cannot add two models", {
   mod <- parsnip::linear_reg()
   mod <- parsnip::set_engine(mod, "lm")


### PR DESCRIPTION
Closes #174. :)

``` r
# note: do not load required parsnip extension
library(parsnip)
library(workflows)

bt_mod <- bag_tree() %>%
  set_engine("rpart") %>%
  set_mode("regression")

bt_wf <- workflow() %>%
  add_model(bt_mod)
#> ! parsnip could not locate an implementation for `bag_tree` regression model
#>   specifications using the `rpart` engine.
#> ℹ The parsnip extension package baguette implements support for this
#>   specification.
#> ℹ Please install (if needed) and load to continue.
```

<sup>Created on 2022-09-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

This PR requires dev parsnip, so won't make it into 1.1.0.