### PR TITLE
use modelenv

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     glue (>= 1.6.2),
     hardhat (>= 1.2.0),
     lifecycle (>= 1.0.1),
+    modelenv,
     parsnip (>= 1.0.0),
     rlang (>= 1.0.3),
     tidyselect (>= 1.1.2),
@@ -37,6 +38,8 @@ Suggests:
     recipes (>= 1.0.0),
     rmarkdown,
     testthat (>= 3.0.0)
+Remotes:
+    emilhvitfeldt/modelenv
 VignetteBuilder: 
     knitr
 Config/Needs/website:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     glue (>= 1.6.2),
     hardhat (>= 1.2.0),
     lifecycle (>= 1.0.3),
-    modelenv,
+    modelenv (>= 0.1.0),
     parsnip (>= 1.0.0),
     rlang (>= 1.0.3),
     tidyselect (>= 1.2.0),
@@ -38,8 +38,6 @@ Suggests:
     recipes (>= 1.0.0),
     rmarkdown,
     testthat (>= 3.0.0)
-Remotes:
-    emilhvitfeldt/modelenv
 VignetteBuilder: 
     knitr
 Config/Needs/website:

--- a/R/fit.R
+++ b/R/fit.R
@@ -252,7 +252,11 @@ pull_workflow_spec_encoding_tbl <- function(workflow) {
   spec <- extract_spec_parsnip(workflow)
   spec_cls <- class(spec)[[1]]
 
-  tbl_encodings <- parsnip::get_encoding(spec_cls)
+  if (modelenv::is_unsupervised_spec(spec)) {
+    tbl_encodings <- modelenv::get_encoding(spec_cls)
+  } else {
+    tbl_encodings <- parsnip::get_encoding(spec_cls)
+  }
 
   indicator_engine <- tbl_encodings$engine == spec$engine
   indicator_mode <- tbl_encodings$mode == spec$mode

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,11 +11,11 @@ glubort <- function(..., .sep = "", .envir = caller_env(), .call = .envir) {
 }
 
 is_model_fit <- function(x) {
-  inherits(x, "model_fit")
+  inherits(x, "model_fit") || modelenv::is_unsupervised_fit(x)
 }
 
 is_model_spec <- function(x) {
-  inherits(x, "model_spec")
+  inherits(x, "model_spec") || modelenv::is_unsupervised_spec(x)
 }
 
 validate_recipes_available <- function(..., call = caller_env()) {


### PR DESCRIPTION
This PR adds modelenv to allow us to work with tidyclust model specifications without direct dependency since modelenv handles all the mode registration.

This PR should not be merged until:

- [x] modelenv gets on CRAN
- [x] DESCRIPTION file gets updated with minimal version of modelenv AND remove modelenv from Remotes