### PR TITLE
re-implement missing extension error on `add_model`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     hardhat (>= 1.2.0),
     lifecycle (>= 1.0.3),
     modelenv (>= 0.1.0),
-    parsnip (>= 1.0.0),
+    parsnip (>= 1.0.2.9003),
     rlang (>= 1.0.3),
     tidyselect (>= 1.2.0),
     vctrs (>= 0.4.1)
@@ -38,6 +38,8 @@ Suggests:
     recipes (>= 1.0.0),
     rmarkdown,
     testthat (>= 3.0.0)
+Remotes:
+    tidymodels/parsnip
 VignetteBuilder: 
     knitr
 Config/Needs/website:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     hardhat (>= 1.2.0),
     lifecycle (>= 1.0.3),
     modelenv (>= 0.1.0),
-    parsnip (>= 1.0.2.9003),
+    parsnip (>= 1.0.3),
     rlang (>= 1.0.3),
     tidyselect (>= 1.2.0),
     vctrs (>= 0.4.1)
@@ -38,8 +38,6 @@ Suggests:
     recipes (>= 1.0.0),
     rmarkdown,
     testthat (>= 3.0.0)
-Remotes:
-    tidymodels/parsnip
 VignetteBuilder: 
     knitr
 Config/Needs/website:

--- a/R/fit-action-model.R
+++ b/R/fit-action-model.R
@@ -190,12 +190,14 @@ new_action_model <- function(spec, formula, ..., call = caller_env()) {
     abort("`formula` must be a formula, or `NULL`.", call = call)
   }
 
-  if (!parsnip::spec_is_loaded(spec = spec)) {
-    parsnip::prompt_missing_implementation(
-      spec = spec,
-      prompt = cli::cli_abort,
-      call = call
-    )
+  if (packageVersion("parsnip") >= "1.0.2.9003") {
+    if (!parsnip::spec_is_loaded(spec = spec)) {
+      parsnip::prompt_missing_implementation(
+        spec = spec,
+        prompt = cli::cli_abort,
+        call = call
+      )
+    }
   }
 
   new_action_fit(spec = spec, formula = formula, subclass = "action_model")

--- a/R/fit-action-model.R
+++ b/R/fit-action-model.R
@@ -190,12 +190,16 @@ new_action_model <- function(spec, formula, ..., call = caller_env()) {
     abort("`formula` must be a formula, or `NULL`.", call = call)
   }
 
-  if (packageVersion("parsnip") >= "1.0.2.9003") {
-    if (!parsnip::spec_is_loaded(spec = spec)) {
-      parsnip::prompt_missing_implementation(
-        spec = spec,
-        prompt = cli::cli_abort,
-        call = call
+  if (utils::packageVersion("parsnip") >= "1.0.2.9003") {
+    if (!rlang::eval_tidy(rlang::call2("spec_is_loaded", spec = spec, .ns = "parsnip"))) {
+      rlang::eval_tidy(
+        rlang::call2(
+          "prompt_missing_implementation",
+          spec = spec,
+          prompt = cli::cli_abort,
+          call = call,
+          .ns = "parsnip"
+        )
       )
     }
   }

--- a/R/fit-action-model.R
+++ b/R/fit-action-model.R
@@ -190,18 +190,12 @@ new_action_model <- function(spec, formula, ..., call = caller_env()) {
     abort("`formula` must be a formula, or `NULL`.", call = call)
   }
 
-  if (utils::packageVersion("parsnip") >= "1.0.2.9003") {
-    if (!rlang::eval_tidy(rlang::call2("spec_is_loaded", spec = spec, .ns = "parsnip"))) {
-      rlang::eval_tidy(
-        rlang::call2(
-          "prompt_missing_implementation",
-          spec = spec,
-          prompt = cli::cli_abort,
-          call = call,
-          .ns = "parsnip"
-        )
-      )
-    }
+  if (!parsnip::spec_is_loaded(spec = spec)) {
+    parsnip::prompt_missing_implementation(
+      spec = spec,
+      prompt = cli::cli_abort,
+      call = call
+    )
   }
 
   new_action_fit(spec = spec, formula = formula, subclass = "action_model")

--- a/R/fit-action-model.R
+++ b/R/fit-action-model.R
@@ -190,5 +190,13 @@ new_action_model <- function(spec, formula, ..., call = caller_env()) {
     abort("`formula` must be a formula, or `NULL`.", call = call)
   }
 
+  if (!parsnip::spec_is_loaded(spec = spec)) {
+    parsnip::prompt_missing_implementation(
+      spec = spec,
+      prompt = cli::cli_abort,
+      call = call
+    )
+  }
+
   new_action_fit(spec = spec, formula = formula, subclass = "action_model")
 }

--- a/tests/testthat/_snaps/fit-action-model.md
+++ b/tests/testthat/_snaps/fit-action-model.md
@@ -15,6 +15,26 @@
       ! `spec` must have a known mode.
       i Set the mode of `spec` by using `parsnip::set_mode()` or by setting the mode directly in the parsnip specification function.
 
+# prompt on spec without a loaded implementation (#174)
+
+    Code
+      add_model(workflow, mod)
+    Condition
+      Error in `add_model()`:
+      ! parsnip could not locate an implementation for `bag_tree` regression model specifications.
+      i The parsnip extension package baguette implements support for this specification.
+      i Please install (if needed) and load to continue.
+
+---
+
+    Code
+      workflow(spec = mod)
+    Condition
+      Error in `add_model()`:
+      ! parsnip could not locate an implementation for `bag_tree` regression model specifications.
+      i The parsnip extension package baguette implements support for this specification.
+      i Please install (if needed) and load to continue.
+
 # cannot add two models
 
     Code

--- a/tests/testthat/test-fit-action-model.R
+++ b/tests/testthat/test-fit-action-model.R
@@ -22,6 +22,18 @@ test_that("model must contain a known mode (#160)", {
   })
 })
 
+test_that("prompt on spec without a loaded implementation (#174)", {
+  skip_if(packageVersion("parsnip") < "1.0.2.9003")
+
+  mod <- parsnip::bag_tree() %>%
+    parsnip::set_mode("regression")
+
+  workflow <- workflow()
+
+  expect_snapshot(error = TRUE, add_model(workflow, mod))
+  expect_snapshot(error = TRUE, workflow(spec = mod))
+})
+
 test_that("cannot add two models", {
   mod <- parsnip::linear_reg()
   mod <- parsnip::set_engine(mod, "lm")

--- a/tests/testthat/test-fit-action-model.R
+++ b/tests/testthat/test-fit-action-model.R
@@ -23,8 +23,6 @@ test_that("model must contain a known mode (#160)", {
 })
 
 test_that("prompt on spec without a loaded implementation (#174)", {
-  skip_if(packageVersion("parsnip") < "1.0.2.9003")
-
   mod <- parsnip::bag_tree() %>%
     parsnip::set_mode("regression")
 


### PR DESCRIPTION
Closes #182. A duplicate PR of #175, and that explanation applies, except that this PR is implemented anticipating that workflows will be released before parsnip. This error will thus "kick in" once the new parsnip is on CRAN, whenever that is, and functionality won't change until then.

PRing as draft, in case it ends up looking like we can get parsnip out with the changes in https://github.com/tidymodels/parsnip/pull/836 before dev workflows is submitted to CRAN.