### PR TITLE
only call parsnip::prompt_missing_implementation on parsnip models

### DIFF
--- a/R/fit-action-model.R
+++ b/R/fit-action-model.R
@@ -190,7 +190,7 @@ new_action_model <- function(spec, formula, ..., call = caller_env()) {
     abort("`formula` must be a formula, or `NULL`.", call = call)
   }
 
-  if (!parsnip::spec_is_loaded(spec = spec)) {
+  if (!parsnip::spec_is_loaded(spec = spec) && inherits(spec, "model_spec")) {
     parsnip::prompt_missing_implementation(
       spec = spec,
       prompt = cli::cli_abort,


### PR DESCRIPTION
https://github.com/tidymodels/workflows/commit/b6e352a17f8a7d0d3717498ef137f9171f272694 accidentally broke tidyclust support. This PR fixes that problem.