### PR TITLE
add an eval_time argument to augment()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,8 @@ Config/Needs/website:
     tidyr,
     tidyverse/tidytemplate,
     yardstick
+Remotes:
+    tidymodels/parsnip#960
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Config/Needs/website:
     tidyverse/tidytemplate,
     yardstick
 Remotes:
-    tidymodels/parsnip#960
+    tidymodels/parsnip
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     hardhat (>= 1.2.0),
     lifecycle (>= 1.0.3),
     modelenv (>= 0.1.0),
-    parsnip (>= 1.0.3),
+    parsnip (>= 1.1.0.9001),
     rlang (>= 1.0.3),
     tidyselect (>= 1.2.0),
     vctrs (>= 0.4.1)

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 * Each of the `pull_*()` functions soft-deprecated in workflows v0.2.3 now warn on every usage. 
 
+* `augment.workflow()` gained an `eval_time` argument, enabling augmenting
+  censored regression models (#200).
+
+* The prediction columns are now appended to the LHS rather than RHS of 
+  `new_data` in `augment.workflow()`, following analogous changes in parsnip (#200).
+
 # workflows 1.1.3
 
 * The workflows methods for `generics::tune_args()` and `generics::tunable()`

--- a/R/broom.R
+++ b/R/broom.R
@@ -109,6 +109,10 @@ glance.workflow <- function(x, ...) {
 #'
 #' @return `new_data` with new prediction specific columns.
 #'
+#' @param eval_time For censored regression models, a vector of time points at
+#' which the survival probability is estimated. See
+#' [parsnip::augment.model_fit()] for more details.
+#'
 #' @export
 #' @examples
 #' if (rlang::is_installed("broom")) {
@@ -133,13 +137,13 @@ glance.workflow <- function(x, ...) {
 #' augment(wf_fit, attrition)
 #'
 #' }
-augment.workflow <- function(x, new_data, ...) {
+augment.workflow <- function(x, new_data, eval_time = NULL, ...) {
   fit <- extract_fit_parsnip(x)
 
   # `augment.model_fit()` requires the pre-processed `new_data`
   predictors <- forge_predictors(new_data, x)
   predictors <- prepare_augment_predictors(predictors)
-  predictors_and_predictions <- augment(fit, predictors, ...)
+  predictors_and_predictions <- augment(fit, predictors, eval_time = eval_time, ...)
 
   prediction_columns <- setdiff(
     names(predictors_and_predictions),

--- a/R/broom.R
+++ b/R/broom.R
@@ -153,7 +153,7 @@ augment.workflow <- function(x, new_data, eval_time = NULL, ...) {
   predictions <- predictors_and_predictions[prediction_columns]
 
   # Return original `new_data` with new prediction columns
-  out <- vctrs::vec_cbind(new_data, predictions)
+  out <- vctrs::vec_cbind(predictions, new_data)
 
   out
 }

--- a/man/augment.workflow.Rd
+++ b/man/augment.workflow.Rd
@@ -4,12 +4,16 @@
 \alias{augment.workflow}
 \title{Augment data with predictions}
 \usage{
-\method{augment}{workflow}(x, new_data, ...)
+\method{augment}{workflow}(x, new_data, eval_time = NULL, ...)
 }
 \arguments{
 \item{x}{A workflow}
 
 \item{new_data}{A data frame of predictors}
+
+\item{eval_time}{For censored regression models, a vector of time points at
+which the survival probability is estimated. See
+\code{\link[parsnip:augment]{parsnip::augment.model_fit()}} for more details.}
 
 \item{...}{Arguments passed on to methods}
 }

--- a/man/predict-workflow.Rd
+++ b/man/predict-workflow.Rd
@@ -40,7 +40,7 @@ the standard error of fit or prediction (on the scale of the
 linear predictors). Default value is \code{FALSE}.
 \item \code{quantile}: for \code{type} equal to \code{quantile}, the quantiles of the
 distribution. Default is \code{(1:9)/10}.
-\item \code{time}: for \code{type} equal to \code{"survival"} or \code{"hazard"}, the
+\item \code{eval_time}: for \code{type} equal to \code{"survival"} or \code{"hazard"}, the
 time points at which the survival probability or hazard is estimated.
 }}
 }

--- a/tests/testthat/test-broom.R
+++ b/tests/testthat/test-broom.R
@@ -100,6 +100,8 @@ test_that("can augment using a fitted workflow's model", {
 
   # at least 1 prediction specific column should be added
   expect_true(ncol(x) > ncol(df))
+
+  expect_named(x, c(".pred", "y", "x"))
 })
 
 test_that("augment returns `new_data`, not the pre-processed version of `new_data`", {


### PR DESCRIPTION
updates for tidymodels/parsnip#960

Since workflows does not use dplyr (!) I'll let you do the column relocation similar to what is in the parsnip PR