### PR TITLE
adapt test on interaction w/ parsnip re intercept

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
     hardhat (>= 1.2.0),
     lifecycle (>= 1.0.3),
     modelenv (>= 0.1.0),
-    parsnip (>= 1.1.0.9001),
+    parsnip (>= 1.1.1.9004),
     rlang (>= 1.0.3),
     tidyselect (>= 1.2.0),
     vctrs (>= 0.4.1)

--- a/tests/testthat/_snaps/pre-action-recipe.md
+++ b/tests/testthat/_snaps/pre-action-recipe.md
@@ -22,7 +22,7 @@
       Error in `add_recipe()`:
       ! A recipe cannot be added when variables already exist.
 
-# cannot add a recipe if recipes is trained
+# cannot add a recipe if recipe is trained
 
     Code
       add_recipe(workflow, rec)

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -138,7 +138,7 @@ test_that("monitoring: no double intercept due to dot expansion in model formula
   mod <- parsnip::linear_reg()
   mod <- parsnip::set_engine(mod, "lm")
 
-  # model formula includes a dot to mean "everything available after the preprocesing formula
+  # model formula includes a dot to mean "everything available after the preprocessing formula
   workflow <- workflow()
   workflow <- add_model(workflow, mod, formula = mpg ~ .)
 
@@ -148,7 +148,7 @@ test_that("monitoring: no double intercept due to dot expansion in model formula
 
   # The dot expansion used to include the intercept column, added via the blueprint, as a regular predictor.
   # `parsnip:::prepare_data()` removed this column, so lm's predict method errored.
-  # Now it get removed before fitting (lm will handle the intercept itself),
-  # so lm()'s predict method won't error anymore here.
+  # Now it gets removed before fitting (lm will handle the intercept itself),
+  # so lm()'s predict method won't error anymore here. (tidymodels/parsnip#1033)
   expect_no_error(predict(fit_with_intercept, mtcars))
 })

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -134,20 +134,21 @@ test_that("blueprint will get passed on to hardhat::forge()", {
   )
 })
 
-test_that("monitoring: known that parsnip removes blueprint intercept for some models (tidymodels/parsnip#353)", {
+test_that("monitoring: no double intercept due to dot expansion in model formula #210", {
   mod <- parsnip::linear_reg()
   mod <- parsnip::set_engine(mod, "lm")
 
-  # Pass formula explicitly to keep `lm()` from auto-generating an intercept
+  # model formula includes a dot to mean "everything available after the preprocesing formula
   workflow <- workflow()
-  workflow <- add_model(workflow, mod, formula = mpg ~ . + 0)
+  workflow <- add_model(workflow, mod, formula = mpg ~ .)
 
   blueprint_with_intercept <- hardhat::default_formula_blueprint(intercept = TRUE)
   workflow_with_intercept <- add_formula(workflow, mpg ~ hp + disp, blueprint = blueprint_with_intercept)
   fit_with_intercept <- fit(workflow_with_intercept, mtcars)
 
-  # `parsnip:::prepare_data()` will remove the intercept, so it won't be
-  # there when the `lm()` `predict()` method is called. We don't own this
-  # error though.
-  expect_error(predict(fit_with_intercept, mtcars))
+  # The dot expansion used to include the intercept column, added via the blueprint, as a regular predictor.
+  # `parsnip:::prepare_data()` removed this column, so lm's predict method errored.
+  # Now it get removed before fitting (lm will handle the intercept itself),
+  # so lm()'s predict method won't error anymore here.
+  expect_no_error(predict(fit_with_intercept, mtcars))
 })


### PR DESCRIPTION
This one is one with a larger backstory ✍️ 

But maybe the best way in is #210 - the crux here is that workflows added an intercept column (in the test because of the very explicit blueprint, in the issue based on the default to consult the parsnip encodings for the engine) which got treated as a regular predictor by the dot expansion in the model formula. This should not happen, this is what the issue captures.

parsnip's functionality for dealing with that intercept column removed it but because it had entered the terms for the `lm`,`predict.lm()` expected it to be there and errored. That is what this test used to capture.

Now parsnip removes the intercept before it enters the terms (https://github.com/tidymodels/parsnip/pull/1033), hence `predict.lm()` does not fail anymore.

I've adapted the test to try to reflect that. Happy to tweak it if it doesn't come across sufficiently. Alternatively, we could also remove the test since it's covered in extratests also.

It does add a dependency on dev parsnip. It was already in the `Remote:` section of the description but maybe that was leftover since the version requirement for parsnip was for prior the `1.1.1` version. So maybe that dependency on the dev version is new?