### PR TITLE
bump minimum required R version

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,8 +25,6 @@ jobs:
           - {os: macOS-latest,   r: 'release'}
 
           - {os: windows-latest, r: 'release'}
-          # Use 3.6 to trigger usage of RTools35
-          - {os: windows-latest, r: '3.6'}
 
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL: https://github.com/tidymodels/workflows,
     https://workflows.tidymodels.org
 BugReports: https://github.com/tidymodels/workflows/issues
 Depends: 
-    R (>= 3.6)
+    R (>= 4.0)
 Imports: 
     cli (>= 3.3.0),
     generics (>= 0.1.2),


### PR DESCRIPTION
🚀

Not the first in tidymodels to do so, e.g. [in tune](https://github.com/tidymodels/tune/blob/c6cf69f5ebd7d7c4af554b1a341ebc26f2f2cfbb/DESCRIPTION#L18).