### PR TITLE
remove hardhat and recipes `Remotes` entries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,8 +49,6 @@ Config/Needs/website:
     tidyverse/tidytemplate,
     yardstick
 Remotes:
-    tidymodels/hardhat,
-    tidymodels/recipes,
     tidymodels/rsample,
     tidymodels/parsnip,
     tidymodels/tailor


### PR DESCRIPTION
hardhat 1.4.0 made it to CRAN a week ago and recipes 1.1.0 made it to CRAN two weeks ago. :)