### PR TITLE
`add_variables()` added to `stages` article, closes #190

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,4 +55,4 @@ Remotes:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # workflows (development version)
 
+* `add_variables()` reference added to `stages` vignette (@brshallo, #190).
 * New `extract_fit_time()` method has been added that return the time it took to train the workflow. (#191)
 
 # workflows 1.1.4

--- a/man/add_model.Rd
+++ b/man/add_model.Rd
@@ -43,6 +43,13 @@ the workflow.
 \code{add_model()} is a required step to construct a minimal workflow.
 }
 \section{Indicator Variable Details}{
+\if{html}{\out{<div class="sourceCode">}}\preformatted{## Warning: package 'recipes' was built under R version 4.3.3
+
+## Warning: package 'dplyr' was built under R version 4.3.3
+
+## Warning: package 'modeldata' was built under R version 4.3.3
+}\if{html}{\out{</div>}}
+
 Some modeling functions in R create indicator/dummy variables from
 categorical data when you use a model formula, and some do not. When you
 specify and fit a model with a \code{workflow()}, parsnip and workflows match
@@ -138,8 +145,8 @@ base_wf \%>\%
 ## Target node size:                 5 
 ## Variable importance mode:         none 
 ## Splitrule:                        variance 
-## OOB prediction error (MSE):       7058847504 
-## R squared (OOB):                  0.5894647
+## OOB prediction error (MSE):       7061174475 
+## R squared (OOB):                  0.5893294
 }\if{html}{\out{</div>}}
 
 Note that there are \strong{four} independent variables in the fitted model

--- a/man/fit-workflow.Rd
+++ b/man/fit-workflow.Rd
@@ -127,8 +127,8 @@ base_wf \%>\%
 ## Target node size:                 5 
 ## Variable importance mode:         none 
 ## Splitrule:                        variance 
-## OOB prediction error (MSE):       7058847504 
-## R squared (OOB):                  0.5894647
+## OOB prediction error (MSE):       7061174475 
+## R squared (OOB):                  0.5893294
 }\if{html}{\out{</div>}}
 
 Note that there are \strong{four} independent variables in the fitted model

--- a/man/workflow.Rd
+++ b/man/workflow.Rd
@@ -134,8 +134,8 @@ base_wf \%>\%
 ## Target node size:                 5 
 ## Variable importance mode:         none 
 ## Splitrule:                        variance 
-## OOB prediction error (MSE):       7058847504 
-## R squared (OOB):                  0.5894647
+## OOB prediction error (MSE):       7061174475 
+## R squared (OOB):                  0.5893294
 }\if{html}{\out{</div>}}
 
 Note that there are \strong{four} independent variables in the fitted model

--- a/vignettes/stages.Rmd
+++ b/vignettes/stages.Rmd
@@ -21,9 +21,11 @@ Workflows encompasses the three main stages of the modeling _process_: pre-proce
 
 ## Pre-processing
 
-The two elements allowed for pre-processing are:
+The three elements allowed for pre-processing are:
 
  * A standard [model formula](https://cran.r-project.org/doc/manuals/r-release/R-intro.html#Formulae-for-statistical-models) via `add_formula()`.
+ 
+ * A tidyselect interface via `add_variables()` that [strictly preserves the class](https://www.tidyverse.org/blog/2020/09/workflows-0-2-0/) of your columns.
  
  * A recipe object via `add_recipe()`.
  


### PR DESCRIPTION
Included reference to blog release for workflows 0.2.0 when `add_variables()` was first introduced which may or may not be necessary.