### PR TITLE
error with unused non-NULL `add_tailor(prop)` or `method`

### DIFF
--- a/R/post-action-tailor.R
+++ b/R/post-action-tailor.R
@@ -109,6 +109,17 @@ add_tailor <- function(x, tailor, prop = NULL, method = NULL, ...) {
   res <- add_action(x, action, "tailor")
   if (.should_inner_split(res)) {
     validate_rsample_available()
+  } else {
+    if (!is_null(prop)) {
+      cli_abort(
+        "{.arg prop} will be ignored as {.arg tailor} does not require training."
+      )
+    }
+    if (!is_null(method)) {
+      cli_abort(
+        "{.arg method} will be ignored as {.arg tailor} does not require training."
+      )
+    }
   }
   res
 }

--- a/tests/testthat/_snaps/post-action-tailor.md
+++ b/tests/testthat/_snaps/post-action-tailor.md
@@ -14,3 +14,21 @@
       Error in `add_tailor()`:
       ! A `tailor` action has already been added to this workflow.
 
+# warns when supplied arguments that will be ignored
+
+    Code
+      add_tailor(workflow(), tailor::adjust_probability_threshold(tailor::tailor(),
+      0.2), prop = 0.2)
+    Condition
+      Error in `add_tailor()`:
+      ! `prop` will be ignored as `tailor` does not require training.
+
+---
+
+    Code
+      add_tailor(workflow(), tailor::adjust_probability_threshold(tailor::tailor(),
+      0.2), method = "mc_split")
+    Condition
+      Error in `add_tailor()`:
+      ! `method` will be ignored as `tailor` does not require training.
+

--- a/tests/testthat/test-post-action-tailor.R
+++ b/tests/testthat/test-post-action-tailor.R
@@ -78,6 +78,25 @@ test_that("update a postprocessor after postprocessor fit", {
   expect_equal(workflow_with_post$fit, workflow_with_post_new$fit)
 })
 
+test_that("warns when supplied arguments that will be ignored", {
+  expect_snapshot(
+    error = TRUE,
+    add_tailor(
+      workflow(),
+      tailor::adjust_probability_threshold(tailor::tailor(), .2),
+      prop = .2
+    )
+  )
+  expect_snapshot(
+    error = TRUE,
+    add_tailor(
+      workflow(),
+      tailor::adjust_probability_threshold(tailor::tailor(), .2),
+      method = "mc_split"
+    )
+  )
+})
+
 test_that("postprocessor fit aligns with manually fitted version (no calibration)", {
   skip_if_not_installed("modeldata")
 


### PR DESCRIPTION
Closes #255. Opted to just check for non-`NULL` arguments rather than missingness to allow for passing arguments programmatically more easily.

"Does not require training" also doesn't feel quite informative enough, though I don't know if we've landed on standard language for tailors that actually estimate things from data at `fit()` time.