### PR TITLE
Make `predict()` work with sparse data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Suggests:
     tailor (>= 0.0.0.9001),
     covr,
     dials (>= 1.0.0),
+    glmnet,
     knitr,
     magrittr,
     Matrix,
@@ -54,6 +55,7 @@ Config/Needs/website:
     yardstick
 Remotes:
     tidymodels/rsample,
+    tidymodels/recipes,
     tidymodels/parsnip,
     tidymodels/tailor,
     r-lib/sparsevctrs

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,10 @@
 
 * New `extract_fit_time()` method has been added that return the time it took to train the workflow (#191).
 
+* `fit()` can now take dgCMatrix and sparse tibbles as data values when `add_recipe()` or `add_variables()` is used (#245, #258).
+
+* `predict()` can now take dgCMatrix and sparse tibble input for `new_data` argument (#261).
+
 # workflows 1.1.4
 
 * While `augment.workflow()` previously never returned a `.resid` column, the 

--- a/R/predict.R
+++ b/R/predict.R
@@ -59,6 +59,10 @@ predict.workflow <- function(object, new_data, type = NULL, opts = list(), ...) 
     ))
   }
 
+  if (is_sparse_matrix(new_data)) {
+    new_data <- sparsevctrs::coerce_to_sparse_tibble(new_data)
+  }
+
   fit <- extract_fit_parsnip(workflow)
   new_data <- forge_predictors(new_data, workflow)
 

--- a/tests/testthat/_snaps/sparsevctrs.md
+++ b/tests/testthat/_snaps/sparsevctrs.md
@@ -28,3 +28,10 @@
     Output
       sparsevctrs: Sparse vector materialized
 
+# sparse matrix can be passed to `predict()
+
+    Code
+      wf_fit <- fit(wf_spec, hotel_data)
+    Output
+      sparsevctrs: Sparse vector materialized
+

--- a/tests/testthat/_snaps/sparsevctrs.md
+++ b/tests/testthat/_snaps/sparsevctrs.md
@@ -28,10 +28,3 @@
     Output
       sparsevctrs: Sparse vector materialized
 
-# sparse matrix can be passed to `predict()
-
-    Code
-      wf_fit <- fit(wf_spec, hotel_data)
-    Output
-      sparsevctrs: Sparse vector materialized
-

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -121,7 +121,7 @@ test_that("sparse matrices can be passed to `fit() - xy", {
   expect_snapshot(wf_fit <- fit(wf_spec, hotel_data))
 })
 
-test_that("sparse tibble can be passed to `predict()", {
+test_that("sparse tibble can be passed to `predict()`", {
   skip_if_not_installed("glmnet")
   # Make materialization of sparse vectors throw an error
   # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
@@ -144,7 +144,7 @@ test_that("sparse tibble can be passed to `predict()", {
   expect_no_error(predict(wf_fit, hotel_data))
 })
 
-test_that("sparse matrix can be passed to `predict()", {
+test_that("sparse matrix can be passed to `predict()`", {
   skip_if_not_installed("glmnet")
   # Make materialization of sparse vectors throw a message
   # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
@@ -162,9 +162,7 @@ test_that("sparse matrix can be passed to `predict()", {
     add_recipe(rec) %>%
     add_model(spec)
 
-  expect_snapshot(
-    wf_fit <- fit(wf_spec, hotel_data)
-  )
+  wf_fit <- fit(wf_spec, hotel_data)
   
   expect_no_error(predict(wf_fit, hotel_data))
 })

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -120,3 +120,51 @@ test_that("sparse matrices can be passed to `fit() - xy", {
   # We expect 1 materialization - the outcome
   expect_snapshot(wf_fit <- fit(wf_spec, hotel_data))
 })
+
+test_that("sparse tibble can be passed to `predict()", {
+  skip_if_not_installed("glmnet")
+  # Make materialization of sparse vectors throw an error
+  # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
+  withr::local_options("sparsevctrs.verbose_materialize" = 3)
+
+  hotel_data <- sparse_hotel_rates(tibble = TRUE)
+
+  spec <- parsnip::linear_reg(penalty = 0) %>%
+    parsnip::set_mode("regression") %>%
+    parsnip::set_engine("glmnet")
+
+  rec <- recipes::recipe(avg_price_per_room ~ ., data = hotel_data)
+
+  wf_spec <- workflow() %>%
+    add_recipe(rec) %>%
+    add_model(spec)
+
+  wf_fit <- fit(wf_spec, hotel_data)
+  
+  expect_no_error(predict(wf_fit, hotel_data))
+})
+
+test_that("sparse matrix can be passed to `predict()", {
+  skip_if_not_installed("glmnet")
+  # Make materialization of sparse vectors throw a message
+  # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
+  withr::local_options("sparsevctrs.verbose_materialize" = 1)
+
+  hotel_data <- sparse_hotel_rates()
+
+  spec <- parsnip::linear_reg(penalty = 0) %>%
+    parsnip::set_mode("regression") %>%
+    parsnip::set_engine("glmnet")
+
+  rec <- recipes::recipe(avg_price_per_room ~ ., data = hotel_data)
+
+  wf_spec <- workflow() %>%
+    add_recipe(rec) %>%
+    add_model(spec)
+
+  expect_snapshot(
+    wf_fit <- fit(wf_spec, hotel_data)
+  )
+  
+  expect_no_error(predict(wf_fit, hotel_data))
+})

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -146,9 +146,9 @@ test_that("sparse tibble can be passed to `predict()`", {
 
 test_that("sparse matrix can be passed to `predict()`", {
   skip_if_not_installed("glmnet")
-  # Make materialization of sparse vectors throw a message
+  # Make materialization of sparse vectors throw a warning
   # https://r-lib.github.io/sparsevctrs/dev/reference/sparsevctrs_options.html
-  withr::local_options("sparsevctrs.verbose_materialize" = 1)
+  withr::local_options("sparsevctrs.verbose_materialize" = 2)
 
   hotel_data <- sparse_hotel_rates()
 
@@ -162,7 +162,10 @@ test_that("sparse matrix can be passed to `predict()`", {
     add_recipe(rec) %>%
     add_model(spec)
 
-  wf_fit <- fit(wf_spec, hotel_data)
+  # We know that this will cause 1 warning due to the outcome
+  suppressWarnings(
+    wf_fit <- fit(wf_spec, hotel_data)
+  )
   
-  expect_no_error(predict(wf_fit, hotel_data))
+  expect_no_warning(predict(wf_fit, hotel_data))
 })


### PR DESCRIPTION
Ref: https://github.com/tidymodels/workflows/issues/239

This PR:
- turns sparse matrices to sparse tibbles early in `predict()` (same convention as with everything else)
- tests that predict works with sparse tibbles and sparse matrices
- add news