### PR TITLE
Data usage for `add_tailor()`

### DIFF
--- a/R/post-action-tailor.R
+++ b/R/post-action-tailor.R
@@ -50,7 +50,7 @@
 #' ```
 #' boots <- rsample::bootstraps(some_other_data)
 #' split <- rsample::get_rsplit(boots, 1)
-#' data <- rsample::assessment(split)
+#' data <- rsample::analysis(split)
 #' ```
 #'
 #' In this case, some of the rows in `data` will be duplicated. Thus, randomly

--- a/man/add_tailor.Rd
+++ b/man/add_tailor.Rd
@@ -68,7 +68,7 @@ leakage. However, \code{fit.workflow(data)} could also have arisen as:
 
 \if{html}{\out{<div class="sourceCode">}}\preformatted{boots <- rsample::bootstraps(some_other_data)
 split <- rsample::get_rsplit(boots, 1)
-data <- rsample::assessment(split)
+data <- rsample::analysis(split)
 }\if{html}{\out{</div>}}
 
 In this case, some of the rows in \code{data} will be duplicated. Thus, randomly


### PR DESCRIPTION
For the bootstrap, the analysis set has the replications, while the assessment set has the out-of-bag samples; thus, there are no duplicates.