### PR TITLE
apply postprocessor in `augment.workflow()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: workflows
 Title: Modeling Workflows
-Version: 1.1.4.9000
+Version: 1.1.4.9001
 Authors@R: c(
     person("Davis", "Vaughan", , "davis@posit.co", role = "aut"),
     person("Simon", "Couch", , "simon.couch@posit.co", role = c("aut", "cre"),

--- a/R/broom.R
+++ b/R/broom.R
@@ -159,6 +159,11 @@ augment.workflow <- function(x, new_data, eval_time = NULL, ...) {
   new_data_forged <- prepare_augment_new_data(new_data_forged)
   out <- augment(fit, new_data_forged, eval_time = eval_time, ...)
 
+  if (has_postprocessor_tailor(x)) {
+    post <- extract_postprocessor(x)
+    out <- predict(post, new_data = out)
+  }
+
   augment_columns <- setdiff(
     names(out),
     names(new_data_forged)

--- a/tests/testthat/test-broom.R
+++ b/tests/testthat/test-broom.R
@@ -106,6 +106,34 @@ test_that("can augment using a fitted workflow's model", {
   expect_named(x, c(".pred", ".resid", "y", "x"))
 })
 
+test_that("can augment with a postprocessor (#275)", {
+  skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
+
+  cal_post <-
+    tailor::tailor() %>%
+    tailor::adjust_numeric_calibration(method = "isotonic_boot")
+
+  wflow <- workflow(mpg ~ ., parsnip::linear_reg())
+  wflow_post <- workflow(mpg ~ ., parsnip::linear_reg(), cal_post)
+
+  # fit the postprocessor as part of the workflow
+  set.seed(1)
+  fit_post <- fit(wflow_post, data = mtcars[1:20,], calibration = mtcars[20:30,])
+  pred_post <- fit_post %>% augment(mtcars[31:32,])
+
+  # manually fit the model and the apply the postprocessor
+  set.seed(1)
+  fit_model <- fit(wflow, mtcars[1:20,])
+  post_fit <- extract_postprocessor(fit_post)$adjustments[[1]]$results$fit
+  pred_post_manual <- probably::cal_apply(
+    augment(fit_model, mtcars[31:32,]),
+    post_fit
+  )
+
+  expect_equal(pred_post, pred_post_manual, ignore_attr = TRUE)
+})
+
 test_that("can augment without outcome column", {
   skip_if_not_installed("broom")
 


### PR DESCRIPTION
Closes #275.

With this PR:

``` r
library(tidymodels)
library(tailor)
library(probably)
#> 
#> Attaching package: 'probably'
#> The following objects are masked from 'package:base':
#> 
#>     as.factor, as.ordered

tidymodels_prefer()
theme_set(theme_bw())
options(pillar.advice = FALSE, pillar.min_title_chars = Inf)

set.seed(900)
reg_train <- sim_regression(5000)
reg_cal <- sim_regression(500)
reg_test <- sim_regression(500)


rf_spec <- rand_forest(trees = 5, min_n = 200) %>%
  set_mode("regression")

cal_post <- tailor() %>%
  adjust_numeric_calibration(method = "isotonic_boot")

rf_wflow <- workflow(outcome ~ ., rf_spec)
rf_cal_wflow <- workflow(outcome ~ ., rf_spec, cal_post)


set.seed(1)
rf_fit <- fit(rf_wflow, reg_train)
rf_pred <- rf_fit %>% augment(reg_test) 

set.seed(1)
rf_cal_fit <- fit(rf_cal_wflow, data = reg_train, calibration = reg_cal)
rf_cal_pred <- rf_cal_fit %>% augment(reg_test) 

all.equal(rf_pred, rf_cal_pred)
#> [1] "Component \".pred\": Mean relative difference: 0.2442093"
```

<sup>Created on 2025-01-10 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>