### PR TITLE
add `toggle_sparsity()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
     lifecycle (>= 1.0.3),
     modelenv (>= 0.1.0),
     parsnip (>= 1.2.1.9000),
+    recipes (>= 1.0.10.9000),
     rlang (>= 1.1.0),
     tidyselect (>= 1.2.0),
     sparsevctrs (>= 0.1.0.9002),
@@ -42,7 +43,6 @@ Suggests:
     methods,
     modeldata (>= 1.0.0),
     probably,
-    recipes (>= 1.0.10.9000),
     rmarkdown,
     testthat (>= 3.0.0)
 VignetteBuilder: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     recipes (>= 1.0.10.9000),
     rlang (>= 1.1.0),
     tidyselect (>= 1.2.0),
-    sparsevctrs (>= 0.1.0.9002),
+    sparsevctrs (>= 0.1.0.9003),
     vctrs (>= 0.4.1),
     withr
 Suggests: 

--- a/R/fit.R
+++ b/R/fit.R
@@ -71,6 +71,8 @@ fit.workflow <- function(object, data, ..., calibration = NULL, control = contro
     )
   }
 
+  object <- toggle_sparsity(object, data)
+
   workflow <- object
   workflow <- .fit_pre(workflow, data)
   workflow <- .fit_model(workflow, control)

--- a/R/sparsevctrs.R
+++ b/R/sparsevctrs.R
@@ -34,8 +34,27 @@ allow_sparse <- function(x) {
   all(res$allow_sparse_x[res$engine == x$engine])
 }
 
-should_use_sparsity <- function(sparsity, model, n_rows) {
-  if (is.null(model) || model == "ranger") {
+# This function was created using from the output of a mars model fit on the
+# simulation data generated in `analysis/time_analysis.R`
+# https://github.com/tidymodels/benchmark-sparsity-threshold
+#
+# The model was extracted using {tidypredict} and hand-tuned for speed.
+#
+# The model was fit on `sparsity`, `engine` and `n_rows` and the outcome was 
+# `log_fold` which is defined as 
+# `log(time to fit with dense data / time to fit with sparse data)`.
+# Meaning that values above above 0 would reflects longer fit times for dense,
+# Hence we want to use sparse data.
+#
+# At this time the only engines that support sparse data are glmnet, LiblineaR, 
+# ranger, and xgboost. Which is why they are the only ones listed here.
+# This is fine as this code will only run if `allow_sparse()` returns `TRUE`
+# Which only happens for these engines.
+# 
+# Ranger is hard-coded to always fail since they appear to use the same 
+# algorithm for sparse and dense data, resulting in identical times.
+should_use_sparsity <- function(sparsity, engine, n_rows) {
+  if (is.null(engine) || engine == "ranger") {
     return("no")
   }
 
@@ -53,7 +72,7 @@ should_use_sparsity <- function(sparsity, model, n_rows) {
       ifelse(n_rows < 8000, 8000 - n_rows, 0) *
       -0.000798307404212627
 
-  if (model == "xgboost") {
+  if (engine == "xgboost") {
     log_fold <- log_fold +
       ifelse(sparsity < 0.984615384615385, 0.984615384615385 - sparsity, 0) *
         0.113098025073806 +
@@ -64,7 +83,7 @@ should_use_sparsity <- function(sparsity, model, n_rows) {
       0.913457808326756
   }
 
-  if (model == "LiblineaR") {
+  if (engine == "LiblineaR") {
     log_fold <- log_fold +
       ifelse(sparsity > 0.836601307189543, sparsity - 0.836601307189543, 0) *
         -5.39592564852111

--- a/R/sparsevctrs.R
+++ b/R/sparsevctrs.R
@@ -3,31 +3,32 @@ is_sparse_matrix <- function(x) {
 }
 
 toggle_sparsity <- function(object, data) {
-  toggle_sparse <- "no"
-
-  if (allow_sparse(expect_spec_parsnip(object))) {
-    if (has_preprocessor_recipe(object)) {
-      est_sparsity <- recipes::.recipes_estimate_sparsity(
-        extract_preprocessor(object)
-      )
-    } else {
-      est_sparsity <- sparsevctrs::sparsity(data, sample = 1000)
-    }
+  if (
+    allow_sparse(object$fit$actions$model$spec) &&
+      has_preprocessor_recipe(object)
+  ) {
+    est_sparsity <- recipes::.recipes_estimate_sparsity(
+      extract_preprocessor(object)
+    )
 
     pred_log_fold <- pred_log_fold(
       est_sparsity,
       extract_spec_parsnip(object)$engine,
       nrow(data)
     )
+
+    toggle_sparse <- "no"
+
     if (pred_log_fold > 0) {
       toggle_sparse <- "yes"
     }
+
+    object$pre$actions$recipe$recipe <- recipes::.recipes_toggle_sparse_args(
+      object$pre$actions$recipe$recipe,
+      choice = toggle_sparse
+    )
   }
 
-  object$pre$actions$recipe$recipe <- recipes::.recipes_toggle_sparse_args(
-    object$pre$actions$recipe$recipe,
-    choice = toggle_sparse
-  )
   object
 }
 

--- a/R/sparsevctrs.R
+++ b/R/sparsevctrs.R
@@ -1,3 +1,79 @@
 is_sparse_matrix <- function(x) {
   methods::is(x, "sparseMatrix")
 }
+
+toggle_sparsity <- function(object, data) {
+  toggle_sparse <- "no"
+
+  if (allow_sparse(object$fit$actions$model$spec)) {
+    if ("recipe" %in% names(object$pre$actions)) {
+      est_sparsity <- recipes::.recipes_estimate_sparsity(
+        object$pre$actions$recipe$recipe
+      )
+    } else {
+      est_sparsity <- sparsevctrs::sparsity(data, 1000)
+    }
+
+    pred_log_fold <- pred_log_fold(
+      est_sparsity,
+      object$fit$actions$model$spec$engine,
+      nrow(data)
+    )
+    if (pred_log_fold > 0) {
+      toggle_sparse <- "yes"
+    }
+  }
+
+  object$pre$actions$recipe$recipe <- recipes::.recipes_toggle_sparse_args(
+    object$pre$actions$recipe$recipe,
+    choice = toggle_sparse
+  )
+  object
+}
+
+allow_sparse <- function(x) {
+  if (inherits(x, "model_fit")) {
+    x <- x$spec
+  }
+  res <- parsnip::get_from_env(paste0(class(x)[1], "_encoding"))
+  all(res$allow_sparse_x[res$engine == x$engine])
+}
+
+pred_log_fold <- function(sparsity, model, n_rows) {
+  if (is.null(model) || model == "ranger") {
+    return("no")
+  }
+
+  log_fold <- -0.599333138645995 +
+    ifelse(sparsity < 0.836601307189543, 0.836601307189543 - sparsity, 0) *
+      -0.541581853008009 +
+    ifelse(n_rows < 16000, 16000 - n_rows, 0) * 3.23980908942813e-05 +
+    ifelse(n_rows > 16000, n_rows - 16000, 0) * -2.81001152147355e-06 +
+    ifelse(sparsity > 0.836601307189543, sparsity - 0.836601307189543, 0) *
+      9.82444255114058 +
+    ifelse(sparsity > 0.836601307189543, sparsity - 0.836601307189543, 0) *
+      ifelse(n_rows > 8000, n_rows - 8000, 0) *
+      7.27456967763306e-05 +
+    ifelse(sparsity > 0.836601307189543, sparsity - 0.836601307189543, 0) *
+      ifelse(n_rows < 8000, 8000 - n_rows, 0) *
+      -0.000798307404212627
+
+  if (model == "xgboost") {
+    log_fold <- log_fold +
+      ifelse(sparsity < 0.984615384615385, 0.984615384615385 - sparsity, 0) *
+        0.113098025073806 +
+      ifelse(n_rows < 8000, 8000 - n_rows, 0) * -9.77914237255269e-05 +
+      ifelse(n_rows > 8000, n_rows - 8000, 0) * 3.22657666511869e-06 +
+      ifelse(sparsity > 0.984615384615385, sparsity - 0.984615384615385, 0) *
+        41.5180348086939 +
+      0.913457808326756
+  }
+
+  if (model == "LiblineaR") {
+    log_fold <- log_fold +
+      ifelse(sparsity > 0.836601307189543, sparsity - 0.836601307189543, 0) *
+        -5.39592564852111
+  }
+
+  log_fold
+}

--- a/R/sparsevctrs.R
+++ b/R/sparsevctrs.R
@@ -2,6 +2,12 @@ is_sparse_matrix <- function(x) {
   methods::is(x, "sparseMatrix")
 }
 
+# This function takes a workflow and its data. If the model supports sparse data
+# And there is a recipe, then it uses `should_use_sparsity()` to determine
+# whether all the `sparse = "auto"` should be turned to `"yes"` or `"no"` in the
+# recipe.
+#
+# Done using flow chart in https://github.com/tidymodels/workflows/issues/271
 toggle_sparsity <- function(object, data) {
   if (
     allow_sparse(object$fit$actions$model$spec) &&

--- a/R/sparsevctrs.R
+++ b/R/sparsevctrs.R
@@ -5,18 +5,18 @@ is_sparse_matrix <- function(x) {
 toggle_sparsity <- function(object, data) {
   toggle_sparse <- "no"
 
-  if (allow_sparse(object$fit$actions$model$spec)) {
-    if ("recipe" %in% names(object$pre$actions)) {
+  if (allow_sparse(expect_spec_parsnip(object))) {
+    if (has_preprocessor_recipe(object)) {
       est_sparsity <- recipes::.recipes_estimate_sparsity(
-        object$pre$actions$recipe$recipe
+        extract_preprocessor(object)
       )
     } else {
-      est_sparsity <- sparsevctrs::sparsity(data, 1000)
+      est_sparsity <- sparsevctrs::sparsity(data, sample = 1000)
     }
 
     pred_log_fold <- pred_log_fold(
       est_sparsity,
-      object$fit$actions$model$spec$engine,
+      extract_spec_parsnip(object)$engine,
       nrow(data)
     )
     if (pred_log_fold > 0) {

--- a/R/sparsevctrs.R
+++ b/R/sparsevctrs.R
@@ -41,7 +41,7 @@ allow_sparse <- function(x) {
 
 pred_log_fold <- function(sparsity, model, n_rows) {
   if (is.null(model) || model == "ranger") {
-    return("no")
+    return(-Inf)
   }
 
   log_fold <- -0.599333138645995 +

--- a/R/sparsevctrs.R
+++ b/R/sparsevctrs.R
@@ -11,17 +11,11 @@ toggle_sparsity <- function(object, data) {
       extract_preprocessor(object)
     )
 
-    pred_log_fold <- pred_log_fold(
+    toggle_sparse <- should_use_sparsity(
       est_sparsity,
       extract_spec_parsnip(object)$engine,
       nrow(data)
     )
-
-    toggle_sparse <- "no"
-
-    if (pred_log_fold > 0) {
-      toggle_sparse <- "yes"
-    }
 
     object$pre$actions$recipe$recipe <- recipes::.recipes_toggle_sparse_args(
       object$pre$actions$recipe$recipe,
@@ -40,9 +34,9 @@ allow_sparse <- function(x) {
   all(res$allow_sparse_x[res$engine == x$engine])
 }
 
-pred_log_fold <- function(sparsity, model, n_rows) {
+should_use_sparsity <- function(sparsity, model, n_rows) {
   if (is.null(model) || model == "ranger") {
-    return(-Inf)
+    return("no")
   }
 
   log_fold <- -0.599333138645995 +
@@ -76,5 +70,5 @@ pred_log_fold <- function(sparsity, model, n_rows) {
         -5.39592564852111
   }
 
-  log_fold
+  ifelse(log_fold > 0, "yes", "no")
 }

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -197,8 +197,10 @@ test_that("toggle_sparsity changes auto to yes", {
   skip_if_not_installed("modeldata")
 
   data("ames", package = "modeldata")
+  ames <- dplyr::select(ames, Sale_Price, dplyr::where(is.factor))
+  ames <- ames[1:100, ]
 
-  tree_spec <- parsnip::boost_tree("regression", "xgboost")
+  tree_spec <- parsnip::linear_reg("regression", "glmnet", penalty = 0)
 
   rec_spec <- recipes::recipe(Sale_Price ~ ., data = ames) %>%
     recipes::step_dummy(recipes::all_nominal_predictors())
@@ -218,8 +220,10 @@ test_that("toggle_sparsity doesn't change no", {
   skip_if_not_installed("modeldata")
 
   data("ames", package = "modeldata")
+  ames <- dplyr::select(ames, Sale_Price, dplyr::where(is.factor))
+  ames <- ames[1:100, ]
 
-  tree_spec <- parsnip::boost_tree("regression", "xgboost")
+  tree_spec <- parsnip::linear_reg("regression", "glmnet", penalty = 0)
 
   rec_spec <- recipes::recipe(Sale_Price ~ ., data = ames) %>%
     recipes::step_dummy(recipes::all_nominal_predictors(), sparse = "no")
@@ -239,8 +243,10 @@ test_that("toggle_sparsity changes auto to no", {
   skip_if_not_installed("modeldata")
 
   data("ames", package = "modeldata")
+  ames <- dplyr::select(ames, Sale_Price, dplyr::where(is.factor))
+  ames <- ames[1:100, ]
 
-  tree_spec <- parsnip::boost_tree("regression", "xgboost")
+  tree_spec <- parsnip::linear_reg("regression", "glmnet", penalty = 0)
 
   # if we only dummy 1 variable it doesn't make the data sparse enough
   rec_spec <- recipes::recipe(Sale_Price ~ ., data = ames) %>%
@@ -261,8 +267,10 @@ test_that("toggle_sparsity doesn't change yes", {
   skip_if_not_installed("modeldata")
 
   data("ames", package = "modeldata")
+  ames <- dplyr::select(ames, Sale_Price, dplyr::where(is.factor))
+  ames <- ames[1:100, ]
 
-  tree_spec <- parsnip::boost_tree("regression", "xgboost")
+  tree_spec <- parsnip::linear_reg("regression", "glmnet", penalty = 0)
 
   # if we only dummy 1 variable it doesn't make the data sparse enough
   rec_spec <- recipes::recipe(Sale_Price ~ ., data = ames) %>%
@@ -283,8 +291,10 @@ test_that("toggle_sparsity doesn't break fit", {
   skip_if_not_installed("modeldata")
 
   data("ames", package = "modeldata")
+  ames <- dplyr::select(ames, Sale_Price, dplyr::where(is.factor))
+  ames <- ames[1:100, ]
 
-  tree_spec <- parsnip::boost_tree("regression", "xgboost")
+  tree_spec <- parsnip::linear_reg("regression", "glmnet", penalty = 0)
 
   rec_spec <- recipes::recipe(Sale_Price ~ ., data = ames) %>%
     recipes::step_dummy(recipes::all_nominal_predictors())

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -191,3 +191,89 @@ test_that("fit() errors if sparse matrix has no colnames", {
     fit(wf_spec, hotel_data)
   )
 })
+
+test_that("toggle_sparsity changes auto to yes", {
+  skip_if_not_installed("glmnet")
+  skip_if_not_installed("modeldata")
+
+  data("ames", package = "modeldata")
+
+  tree_spec <- parsnip::boost_tree("regression", "xgboost")
+
+  rec_spec <- recipes::recipe(Sale_Price ~ ., data = ames) %>%
+    recipes::step_dummy(recipes::all_nominal_predictors())
+
+  wf_spec <- workflow(rec_spec, tree_spec)
+
+  res <- toggle_sparsity(wf_spec, ames)
+
+  expect_identical(
+    extract_preprocessor(res)$steps[[1]]$sparse,
+    "yes"
+  )
+})
+
+test_that("toggle_sparsity doesn't change no", {
+  skip_if_not_installed("glmnet")
+  skip_if_not_installed("modeldata")
+
+  data("ames", package = "modeldata")
+
+  tree_spec <- parsnip::boost_tree("regression", "xgboost")
+
+  rec_spec <- recipes::recipe(Sale_Price ~ ., data = ames) %>%
+    recipes::step_dummy(recipes::all_nominal_predictors(), sparse = "no")
+
+  wf_spec <- workflow(rec_spec, tree_spec)
+
+  res <- toggle_sparsity(wf_spec, ames)
+
+  expect_identical(
+    extract_preprocessor(res)$steps[[1]]$sparse,
+    "no"
+  )
+})
+
+test_that("toggle_sparsity changes auto to no", {
+  skip_if_not_installed("glmnet")
+  skip_if_not_installed("modeldata")
+
+  data("ames", package = "modeldata")
+
+  tree_spec <- parsnip::boost_tree("regression", "xgboost")
+
+  # if we only dummy 1 variable it doesn't make the data sparse enough
+  rec_spec <- recipes::recipe(Sale_Price ~ ., data = ames) %>%
+    recipes::step_dummy(MS_Zoning)
+
+  wf_spec <- workflow(rec_spec, tree_spec)
+
+  res <- toggle_sparsity(wf_spec, ames)
+
+  expect_identical(
+    extract_preprocessor(res)$steps[[1]]$sparse,
+    "no"
+  )
+})
+
+test_that("toggle_sparsity doesn't change yes", {
+  skip_if_not_installed("glmnet")
+  skip_if_not_installed("modeldata")
+
+  data("ames", package = "modeldata")
+
+  tree_spec <- parsnip::boost_tree("regression", "xgboost")
+
+  # if we only dummy 1 variable it doesn't make the data sparse enough
+  rec_spec <- recipes::recipe(Sale_Price ~ ., data = ames) %>%
+    recipes::step_dummy(MS_Zoning, sparse = "yes")
+
+  wf_spec <- workflow(rec_spec, tree_spec)
+
+  res <- toggle_sparsity(wf_spec, ames)
+
+  expect_identical(
+    extract_preprocessor(res)$steps[[1]]$sparse,
+    "yes"
+  )
+})

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -197,7 +197,14 @@ test_that("toggle_sparsity changes auto to yes", {
   skip_if_not_installed("modeldata")
 
   data("ames", package = "modeldata")
-  ames <- dplyr::select(ames, Sale_Price, dplyr::where(is.factor))
+  fcts <- c(
+    1L, 2L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 
+    17L, 20L, 21L, 22L, 23L, 24L, 26L, 27L, 28L, 29L, 30L, 32L, 36L, 
+    37L, 38L, 39L, 50L, 52L, 53L, 56L, 57L, 64L, 65L, 66L, 70L, 71L
+  )
+  outcome <- 72
+
+  ames <- ames[c(fcts, outcome)]
   ames <- ames[1:100, ]
 
   tree_spec <- parsnip::linear_reg("regression", "glmnet", penalty = 0)
@@ -220,7 +227,14 @@ test_that("toggle_sparsity doesn't change no", {
   skip_if_not_installed("modeldata")
 
   data("ames", package = "modeldata")
-  ames <- dplyr::select(ames, Sale_Price, dplyr::where(is.factor))
+  fcts <- c(
+    1L, 2L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 
+    17L, 20L, 21L, 22L, 23L, 24L, 26L, 27L, 28L, 29L, 30L, 32L, 36L, 
+    37L, 38L, 39L, 50L, 52L, 53L, 56L, 57L, 64L, 65L, 66L, 70L, 71L
+  )
+  outcome <- 72
+
+  ames <- ames[c(fcts, outcome)]
   ames <- ames[1:100, ]
 
   tree_spec <- parsnip::linear_reg("regression", "glmnet", penalty = 0)
@@ -243,7 +257,14 @@ test_that("toggle_sparsity changes auto to no", {
   skip_if_not_installed("modeldata")
 
   data("ames", package = "modeldata")
-  ames <- dplyr::select(ames, Sale_Price, dplyr::where(is.factor))
+  fcts <- c(
+    1L, 2L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 
+    17L, 20L, 21L, 22L, 23L, 24L, 26L, 27L, 28L, 29L, 30L, 32L, 36L, 
+    37L, 38L, 39L, 50L, 52L, 53L, 56L, 57L, 64L, 65L, 66L, 70L, 71L
+  )
+  outcome <- 72
+
+  ames <- ames[c(fcts, outcome)]
   ames <- ames[1:100, ]
 
   tree_spec <- parsnip::linear_reg("regression", "glmnet", penalty = 0)
@@ -267,7 +288,14 @@ test_that("toggle_sparsity doesn't change yes", {
   skip_if_not_installed("modeldata")
 
   data("ames", package = "modeldata")
-  ames <- dplyr::select(ames, Sale_Price, dplyr::where(is.factor))
+  fcts <- c(
+    1L, 2L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 
+    17L, 20L, 21L, 22L, 23L, 24L, 26L, 27L, 28L, 29L, 30L, 32L, 36L, 
+    37L, 38L, 39L, 50L, 52L, 53L, 56L, 57L, 64L, 65L, 66L, 70L, 71L
+  )
+  outcome <- 72
+
+  ames <- ames[c(fcts, outcome)]
   ames <- ames[1:100, ]
 
   tree_spec <- parsnip::linear_reg("regression", "glmnet", penalty = 0)
@@ -291,7 +319,14 @@ test_that("toggle_sparsity doesn't break fit", {
   skip_if_not_installed("modeldata")
 
   data("ames", package = "modeldata")
-  ames <- dplyr::select(ames, Sale_Price, dplyr::where(is.factor))
+  fcts <- c(
+    1L, 2L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 
+    17L, 20L, 21L, 22L, 23L, 24L, 26L, 27L, 28L, 29L, 30L, 32L, 36L, 
+    37L, 38L, 39L, 50L, 52L, 53L, 56L, 57L, 64L, 65L, 66L, 70L, 71L
+  )
+  outcome <- 72
+
+  ames <- ames[c(fcts, outcome)]
   ames <- ames[1:100, ]
 
   tree_spec <- parsnip::linear_reg("regression", "glmnet", penalty = 0)

--- a/tests/testthat/test-sparsevctrs.R
+++ b/tests/testthat/test-sparsevctrs.R
@@ -277,3 +277,22 @@ test_that("toggle_sparsity doesn't change yes", {
     "yes"
   )
 })
+
+test_that("toggle_sparsity doesn't break fit", {
+  skip_if_not_installed("glmnet")
+  skip_if_not_installed("modeldata")
+
+  data("ames", package = "modeldata")
+
+  tree_spec <- parsnip::boost_tree("regression", "xgboost")
+
+  rec_spec <- recipes::recipe(Sale_Price ~ ., data = ames) %>%
+    recipes::step_dummy(recipes::all_nominal_predictors())
+
+  wf_spec <- workflow(rec_spec, tree_spec)
+
+  expect_no_error(
+    fit(wf_spec, ames)
+  )
+})
+


### PR DESCRIPTION
to close https://github.com/tidymodels/workflows/issues/271

I think this is the last puzzle piece to make sparsity useful in tidymodels.

This will toggle the sparsity creation of recipes based on whether or not we estimate it will be useful or not.