### PR TITLE
confirm sparsity failure with CRAN recipes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,7 +55,6 @@ Config/Needs/website:
     yardstick
 Remotes:
     tidymodels/dials,
-    tidymodels/recipes,
     tidymodels/parsnip,
     tidymodels/probably,
     tidymodels/tailor,


### PR DESCRIPTION
`main` workflows GHA, currently with dev recipes, doesn't see an issue with sparsity that the CRAN version does see:

```
── Failure (test-sparsevctrs.R:219:3): toggle_sparsity changes auto to yes ────
extract_preprocessor(res)$steps[[1]]$sparse (`actual`) not identical to "yes" (`expected`).

`actual`:   "no" 
`expected`: "yes"
```

recipes 1.1.1 went to CRAN last week. It appears that sometime between [a month ago](https://github.com/tidymodels/workflows/commit/d963de97a4b0ba722b8e53b5d4efbc330c3f3546) and the recipes CRAN release, this workflows test was broken by recipes, and then since resolved on dev recipes in the last week. Just filing this PR to reproduce this on GHA.

