### PR TITLE
remove remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,11 +49,6 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    r-lib/sparsevctrs,
-    tidymodels/dials,
-    tidymodels/parsnip,
-    tidymodels/probably,
-    tidymodels/recipes,
     tidymodels/tailor
 Config/Needs/website:dplyr, ggplot2, tidyr, tidyverse/tidytemplate,
     yardstick


### PR DESCRIPTION
The CRAN versions are far past the stated versions so let's remove them. 

It may not help but with other packages that depend on workflows, I'm getting GHA errors on R 4.1.3 of 

```
Error: 
  ! error in pak subprocess
  Caused by error: 
  ! Could not solve package dependencies:
  * deps::.: Can't install dependency tidymodels/workflows
  * tidymodels/workflows:
    * Can't install dependency tidymodels/recipes (>= 1.0.10.9000) (>= 0.1.0.9003)
    * Can't install dependency r-lib/sparsevctrs (>= 0.1.0.9003)
  * tidymodels/recipes: ! pkgdepends resolution error for tidymodels/recipes.
  Caused by error: 
  ! Cannot query GitHub, are you offline?
  * r-lib/sparsevctrs: ! pkgdepends resolution error for r-lib/sparsevctrs.
```