### PR TITLE
Check compatibility of model spec and tailor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
     - Include a post stage and integrate post-processors from the tailor package via `add_tailor()`, `remove_tailor()`, `update_tailor()`, `extract_postprocessor()`, and `.fit_post()` (#225).
     - Include post-processing in the workflow methods for `augment()` (#276), `extract_parameter_set_dials()` (#266), `tidy()` (#305), `required_pkgs()` (#299), `tunable()` (#272), and `tune_args()` (#270).
     - `extract_tailor()` extracts the tailor from a workflow (#301).
+    - Checks on compatibility of model spec and tailor (#304).
 
 * Increased the minimum required R version to R 4.1.
 

--- a/R/fit-action-model.R
+++ b/R/fit-action-model.R
@@ -229,7 +229,7 @@ validate_compatibility_model <- function(x, spec, call = caller_env()) {
   post <- extract_postprocessor(x)
 
   if (is_tailor(post)) {
-    validate_compatiblity_model_tailor(
+    validate_compatibility_model_tailor(
       spec,
       post,
       call = call

--- a/R/fit-action-model.R
+++ b/R/fit-action-model.R
@@ -60,7 +60,10 @@
 #' update_model(fitted, regularized_model)
 add_model <- function(x, spec, ..., formula = NULL) {
   check_dots_empty()
+
   action <- new_action_model(spec, formula)
+  validate_compatibility_model(x, spec)
+
   add_action(x, action, "model")
 }
 
@@ -214,4 +217,23 @@ new_action_model <- function(spec, formula, ..., call = caller_env()) {
   }
 
   new_action_fit(spec = spec, formula = formula, subclass = "action_model")
+}
+
+validate_compatibility_model <- function(x, spec, call = caller_env()) {
+  validate_is_workflow(x, call = call)
+
+  if (!has_postprocessor(x)) {
+    return(invisible(x))
+  }
+
+  post <- extract_postprocessor(x)
+
+  if (is_tailor(post)) {
+    validate_compatiblity_model_tailor(
+      spec,
+      post,
+      call = call
+    )
+  }
+  invisible(x)
 }

--- a/R/post-action-tailor.R
+++ b/R/post-action-tailor.R
@@ -205,15 +205,18 @@ validate_compatiblity_model_tailor <- function(
     incompatible_tailor_classification
 
   # check the model mode against the tailor type
-  incompatible_model_censored_regression <- model_mode ==
-    "censored regression" &&
-    tailor_type != "unknown"
+  if (model_mode == "censored regression") {
+    cli_abort(
+      "Post-processing is not available for censored regression models.",
+      call = call
+    )
+  }
+
   incompatible_model_regression <- model_mode == "regression" &&
     !tailor_type %in% c("regression", "unknown")
   incompatible_model_classification <- model_mode == "classification" &&
     !tailor_type %in% c("binary", "multiclass", "unknown")
-  incompatible_model <- incompatible_model_censored_regression ||
-    incompatible_model_regression ||
+  incompatible_model <- incompatible_model_regression ||
     incompatible_model_classification
 
   incompatible <- incompatible_tailor || incompatible_model
@@ -243,4 +246,3 @@ validate_compatibility_tailor <- function(x, tailor, call = caller_env()) {
 
   invisible(x)
 }
-

--- a/R/post-action-tailor.R
+++ b/R/post-action-tailor.R
@@ -205,9 +205,9 @@ validate_compatibility_model_tailor <- function(
     incompatible_tailor_classification
 
   # check the model mode against the tailor type
-  if (model_mode == "censored regression") {
+  if (model_mode %in% c("censored regression", "quantile regression")) {
     cli_abort(
-      "Post-processing is not available for censored regression models.",
+      "Post-processing is not available for {model_mode} models.",
       call = call
     )
   }

--- a/R/post-action-tailor.R
+++ b/R/post-action-tailor.R
@@ -234,7 +234,7 @@ validate_compatibility_model_tailor <- function(
 validate_compatibility_tailor <- function(x, tailor, call = caller_env()) {
   validate_is_workflow(x, call = call)
 
-  if (!has_spec()) {
+  if (!has_spec(x)) {
     return(invisible(x))
   }
 

--- a/R/post-action-tailor.R
+++ b/R/post-action-tailor.R
@@ -234,7 +234,7 @@ validate_compatibility_model_tailor <- function(
 validate_compatibility_tailor <- function(x, tailor, call = caller_env()) {
   validate_is_workflow(x, call = call)
 
-  if (!has_action(x$fit, "model")) {
+  if (!has_spec()) {
     return(invisible(x))
   }
 

--- a/R/post-action-tailor.R
+++ b/R/post-action-tailor.R
@@ -187,7 +187,7 @@ is_tailor <- function(x) {
   inherits(x, "tailor")
 }
 
-validate_compatiblity_model_tailor <- function(
+validate_compatibility_model_tailor <- function(
   model_spec,
   tailor,
   call = caller_env()
@@ -238,7 +238,7 @@ validate_compatibility_tailor <- function(x, tailor, call = caller_env()) {
     return(invisible(x))
   }
 
-  validate_compatiblity_model_tailor(
+  validate_compatibility_model_tailor(
     extract_spec_parsnip(x),
     tailor,
     call = call

--- a/R/workflow.R
+++ b/R/workflow.R
@@ -108,6 +108,8 @@ add_postprocessor <- function(x, postprocessor, ..., call = caller_env()) {
   check_dots_empty()
 
   if (is_tailor(postprocessor)) {
+    # check compatibility here for the right call in the error
+    validate_compatibility_tailor(x, postprocessor, call = call)
     return(add_tailor(x, postprocessor))
   }
 

--- a/R/workflow.R
+++ b/R/workflow.R
@@ -114,7 +114,7 @@ add_postprocessor <- function(x, postprocessor, ..., call = caller_env()) {
   }
 
   cli_abort(
-    "{.arg postprocessor} must be a tailor.",
+    "{.arg postprocessor} must be a {.cls tailor}.",
     call = call
   )
 }

--- a/tests/testthat/_snaps/fit-action-model.md
+++ b/tests/testthat/_snaps/fit-action-model.md
@@ -43,3 +43,11 @@
       Error in `add_model()`:
       ! A `model` action has already been added to this workflow.
 
+# confirms compatibility of model spec and tailor
+
+    Code
+      add_model(workflow, parsnip::linear_reg())
+    Condition
+      Error in `add_model()`:
+      ! The model mode "regression" and the tailor type "binary" are incompatible.
+

--- a/tests/testthat/_snaps/post-action-tailor.md
+++ b/tests/testthat/_snaps/post-action-tailor.md
@@ -6,6 +6,14 @@
       Error in `add_tailor()`:
       ! `tailor` must be a tailor.
 
+# add_tailor() confirms compatibility of model and tailor
+
+    Code
+      add_tailor(workflow, tailor)
+    Condition
+      Error in `add_tailor()`:
+      ! The model mode "regression" and the tailor type "binary" are incompatible.
+
 # cannot add two postprocessors
 
     Code

--- a/tests/testthat/_snaps/workflow.md
+++ b/tests/testthat/_snaps/workflow.md
@@ -46,6 +46,14 @@
       Error in `workflow()`:
       ! `preprocessor` must be a formula, recipe, or a set of workflow variables.
 
+# postprocessor is validated
+
+    Code
+      workflow(postprocessor = 1)
+    Condition
+      Error in `workflow()`:
+      ! `postprocessor` must be a <tailor>.
+
 # constructor validates input
 
     Code

--- a/tests/testthat/_snaps/workflow.md
+++ b/tests/testthat/_snaps/workflow.md
@@ -22,6 +22,14 @@
       Error in `add_model()`:
       ! `x` must be a workflow, not a <numeric>.
 
+# confirms compatibility of model and tailor
+
+    Code
+      workflow(preprocessor = mpg ~ cyl, spec = parsnip::linear_reg(), postprocessor = tailor)
+    Condition
+      Error in `workflow()`:
+      ! The model mode "regression" and the tailor type "binary" are incompatible.
+
 # model spec is validated
 
     Code

--- a/tests/testthat/test-extract.R
+++ b/tests/testthat/test-extract.R
@@ -327,7 +327,7 @@ test_that("extract parameter set from workflow with potentially conflicting ids 
     recipes::recipe(mpg ~ ., mtcars) |>
       recipes::step_pca(recipes::all_predictors(), threshold = hardhat::tune())
   )
-  wflow <- add_model(wflow, parsnip::linear_reg())
+  wflow <- add_model(wflow, parsnip::logistic_reg())
   wflow <- add_tailor(
     wflow,
     tailor::tailor() |>

--- a/tests/testthat/test-fit-action-model.R
+++ b/tests/testthat/test-fit-action-model.R
@@ -85,6 +85,32 @@ test_that("model formula override can contain `offset()` (#162)", {
   expect_identical(attr(lm_result$terms, "offset"), 3L)
 })
 
+test_that("confirms compatibility of model spec and tailor", {
+  skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
+
+  tailor <- tailor::tailor()
+  tailor <- tailor::adjust_probability_threshold(tailor, threshold = .1)
+
+  workflow <- workflow()
+  workflow <- add_formula(workflow, mpg ~ cyl)
+  workflow <- add_tailor(workflow, tailor)
+
+  expect_snapshot(error = TRUE, {
+    add_model(workflow, parsnip::linear_reg())
+  })
+
+  # unknown tailor type
+  tailor <- tailor::tailor()
+  tailor <- tailor::adjust_predictions_custom(tailor, hello = "world")
+
+  workflow <- workflow()
+  workflow <- add_formula(workflow, mpg ~ cyl)
+  workflow <- add_tailor(workflow, tailor)
+
+  expect_no_error(add_model(workflow, parsnip::linear_reg()))
+})
+
 test_that("remove a model", {
   lm_model <- parsnip::linear_reg()
   lm_model <- parsnip::set_engine(lm_model, "lm")

--- a/tests/testthat/test-post-action-tailor.R
+++ b/tests/testthat/test-post-action-tailor.R
@@ -14,6 +14,27 @@ test_that("postprocessor is validated", {
   expect_snapshot(error = TRUE, add_tailor(workflow(), 1))
 })
 
+test_that("add_tailor() confirms compatibility of model and tailor", {
+  skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
+
+  tailor <- tailor::tailor()
+  tailor <- tailor::adjust_probability_threshold(tailor, threshold = .1)
+
+  workflow <- workflow()
+  workflow <- add_formula(workflow, mpg ~ cyl)
+  workflow <- add_model(workflow, parsnip::linear_reg())
+
+  expect_snapshot(error = TRUE, {
+    add_tailor(workflow, tailor)
+  })
+
+  # unknown tailor type
+  tailor <- tailor::tailor()
+  tailor <- tailor::adjust_predictions_custom(tailor, hello = "world")
+  expect_no_error(add_tailor(workflow, tailor))
+})
+
 test_that("cannot add two postprocessors", {
   post <- tailor::tailor()
 

--- a/tests/testthat/test-workflow.R
+++ b/tests/testthat/test-workflow.R
@@ -95,6 +95,10 @@ test_that("preprocessor is validated", {
   expect_snapshot(error = TRUE, workflow(preprocessor = 1))
 })
 
+test_that("postprocessor is validated", {
+  expect_snapshot(error = TRUE, workflow(postprocessor = 1))
+})
+
 # ------------------------------------------------------------------------------
 # new_workflow()
 

--- a/tests/testthat/test-workflow.R
+++ b/tests/testthat/test-workflow.R
@@ -51,6 +51,42 @@ test_that("can add a preprocessor directly to a workflow", {
   expect_identical(workflow$pre$actions$variables$variables, preprocessor)
 })
 
+test_that("can add a postprocessor directly to a workflow", {
+  skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
+
+  tlr <- tailor::tailor()
+  workflow <- workflow(postprocessor = tlr)
+  expect_identical(workflow$post$actions$tailor$tailor, tlr)
+})
+
+test_that("confirms compatibility of model and tailor", {
+  skip_if_not_installed("tailor")
+  skip_if_not_installed("probably")
+
+  tailor <- tailor::tailor()
+  tailor <- tailor::adjust_probability_threshold(tailor, threshold = .1)
+
+  expect_snapshot(error = TRUE, {
+    workflow(
+      preprocessor = mpg ~ cyl,
+      spec = parsnip::linear_reg(),
+      postprocessor = tailor
+    )
+  })
+
+  # unknown tailor type
+  tailor <- tailor::tailor()
+  tailor <- tailor::adjust_predictions_custom(tailor, hello = "world")
+  expect_no_error(
+    workflow(
+      preprocessor = mpg ~ cyl,
+      spec = parsnip::linear_reg(),
+      postprocessor = tailor
+    )
+  )
+})
+
 test_that("model spec is validated", {
   expect_snapshot(error = TRUE, workflow(spec = 1))
 })


### PR DESCRIPTION
closes #291

Parsnip `model_spec`s can have a mode of `"classification"`, `"regression"`, `"censored regression"` or `"unknown"`. When adding a model spec to a workflow, the mode cannot be unknown anymore.

Tailors can have a `type` of `"regression"`, `"binary"`, `"multiclass"` or `"unknown"`. There is currently no way for the user to set the type directly, so workflows does not require the tailor to have a type other than unknown.

Tailors start with an unknown mode (via `tailor::tailor()`) and then the type gets inferred from the adjustments added. 

When we add a tailor to a workflow, it will have
- `type = "unknown"` only if it's a tailor without any adjustments, or all adjustments are `adjust_predictions_custom()`.
- `type = "binary"` for all classification problems, including multi-class. The `type` only gets updated during `fit.tailor()`.
- or otherwise: `type = "regression"`

Once it comes to fitting a tailor, we have the response, so we can update the tailor type 
- from `"unknown"` to one of the other ones
- from `"binary"` to `"multiclass"` if appropriate

This PR checks what we can when specifying the workflow, in `add_tailor()`, `add_model()`, and `workflows()`.

In those situations where `fit.tailor()` changes the tailor type, we can't really do anything earlier, or are fine already:
- If the `"unknown"` tailor type gets changed, it was either a plain tailor (which is fine) or only custom adjustments (which we can't check).
- If the type gets changed from `"binary"` to `"multiclass"`, we already checked that the model mode is `"classification"`.